### PR TITLE
Fix for constrained Permissions in AWS

### DIFF
--- a/templates/oodle-master.template
+++ b/templates/oodle-master.template
@@ -739,7 +739,7 @@
             "Default": "oodlejobs"
         },
         "GitAdminUserid": {
-            "Description": "User Id of Git administrator",
+            "Description": "Unique user Id of Git administrator, must be different than GitTacUserid",
             "Type": "String",
             "Default": "tadmin"
         },
@@ -749,12 +749,12 @@
             "NoEcho": "true"
         },
         "GitAdminEmail": {
-            "Description": "Email address of Git administrator",
+            "Description": "Unique email address of Git administrator, must be different than GitTacEmail",
             "Type": "String",
             "Default": ""
         },
         "GitTacUserid": {
-            "Description": "User id for GIT TAC",
+            "Description": "Unique user id for GIT TAC, must be different than GitAdminUserid",
             "Type": "String",
             "Default": "tac"
         },
@@ -764,7 +764,7 @@
             "NoEcho": "true"
         },
         "GitTacEmail": {
-            "Description": "Contact email address for TAC",
+            "Description": "Unique contact email address for TAC, must be different than GitAdminEmail",
             "Type": "String",
             "Default": ""
         },

--- a/templates/oodle.template
+++ b/templates/oodle.template
@@ -255,9 +255,6 @@
                 "RedshiftNodeType": {
                     "default": "Redshift Node Type"
                 },
-                "RedshiftNodeType": {
-                    "default": "Redshift Node Type"
-                },
                 "RedshiftNumberOfNodes": {
                     "default": "No. of Nodes in Redshift Cluster"
                 },
@@ -792,7 +789,7 @@
             "Default": "5"
         },
         "DistantRunAutoscaleDesiredCapacity": {
-            "Description": "Desired no. of EC2 instances for Talend DistantRun Autoscale group",
+            "Description": "Desired number of EC2 instances for Talend DistantRun Autoscale group",
             "Type": "Number",
             "MinValue": "1",
             "MaxValue": "10",
@@ -821,7 +818,7 @@
             "Default": "oodlejobs"
         },
         "GitAdminUserid": {
-            "Description": "User Id of Git administrator",
+            "Description": "Unique user id of Git administrator, must be different than GitTacUserid",
             "Type": "String",
             "Default": "tadmin"
         },
@@ -831,12 +828,12 @@
             "NoEcho": "true"
         },
         "GitAdminEmail": {
-            "Description": "Email address of Git administrator",
+            "Description": "Unique email address of Git administrator, must be different than GitTacEmail",
             "Type": "String",
             "Default": ""
         },
         "GitTacUserid": {
-            "Description": "User id for GIT TAC",
+            "Description": "Unique user id for GIT TAC, must be different than GitAdminUserid",
             "Type": "String",
             "Default": "tac"
         },
@@ -846,7 +843,7 @@
             "NoEcho": "true"
         },
         "GitTacEmail": {
-            "Description": "Contact email address for TAC",
+            "Description": "Unique contact email address for TAC, must be different than GitAdminEmail",
             "Type": "String",
             "Default": ""
         },


### PR DESCRIPTION
We need this pull request so that  things work correctly in the AWS quickstart-reference bucket since there is no ListBucket permission and we use aws s3 cp with --recursive.