### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+taskcat_outputs/
+ci/taskcat-dev*
+maint/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can also use the AWS CloudFormation templates as a starting point for your o
 
 ![Quick Start architecture for data lake on AWS](https://d0.awsstatic.com/partner-network/QuickStart/datasheets/data-lake-talend-on-aws-architecture.png)
 
-For architectural details, step-by-step instructions, and customization options, see the [deployment guide](https://s3.amazonaws.com/quickstart-reference/datalake/cognizant/talend/latest/doc/data-lake-on-the-aws-cloud-with-talend-big-data-platform.pdf).
+For architectural details, step-by-step instructions, and customization options, see the [deployment guide](https://fwd.aws/aRXaY).
 
 To post feedback, submit feature ideas, or report bugs, use the **Issues** section of this GitHub repo.
 If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/).

--- a/ci/input.json
+++ b/ci/input.json
@@ -5,39 +5,39 @@
   },
   {
       "ParameterKey": "NexusAdminPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "TacPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "MasterDbPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "TacDbPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "AmcDbPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "RedshiftPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "GitAdminPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "GitTacPassword",
-      "ParameterValue": "$[alfred_genpass_16]"
+      "ParameterValue": "$[taskcat_genpass_16]"
   },
   {
       "ParameterKey": "AvailabilityZones",
-      "ParameterValue": "$[alfred_genaz_2]"
+      "ParameterValue": "$[taskcat_genaz_2]"
   },
   {
       "ParameterKey": "KeyPairName",

--- a/ci/input.json
+++ b/ci/input.json
@@ -49,7 +49,7 @@
   },
   {
       "ParameterKey": "RedshiftNodeType",
-      "ParameterValue": "dc1.large"
+      "ParameterValue": "ds2.xlarge"
   },
   {
       "ParameterKey": "QSS3BucketName",

--- a/ci/input.json
+++ b/ci/input.json
@@ -48,7 +48,11 @@
       "ParameterValue": "10.0.0.0/16"
   },
   {
-    "ParameterKey": "RedshiftNodeType",
-    "ParameterValue": "dc1.large"
+      "ParameterKey": "RedshiftNodeType",
+      "ParameterValue": "dc1.large"
+  },
+  {
+      "ParameterKey": "QSS3BucketName",
+      "ParameterValue": "$[taskcat_autobucket]"
   }
 ]

--- a/ci/input.json
+++ b/ci/input.json
@@ -46,5 +46,9 @@
   {
       "ParameterKey": "RemoteAccessCIDR",
       "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "RedshiftNodeType",
+    "ParameterValue": "dc1.large"
   }
 ]

--- a/ci/input.json
+++ b/ci/input.json
@@ -48,6 +48,10 @@
       "ParameterValue": "10.0.0.0/16"
   },
   {
+      "ParameterKey": "RedshiftDbName",
+      "ParameterValue": "tempdb"
+  },
+  {
       "ParameterKey": "RedshiftNodeType",
       "ParameterValue": "ds2.xlarge"
   },

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -1,0 +1,26 @@
+global:
+  marketplace-ami: false
+  owner: quickstart-eng@amazon.com
+  qsname: quickstart-datalake-cognizant-talend
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - ca-central-1
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+  reporting: true
+ 
+tests:
+  quickstart-datalake-cognizant-talendt1:
+    parameter_input: input.json
+    template_file: oodle-master.template
+    regions:
+      - us-east-1

--- a/templates/credential-store.template
+++ b/templates/credential-store.template
@@ -249,7 +249,7 @@
             "Type": "AWS::Lambda::Function",
             "DependsOn": "LambdaExecutionRole",
             "Properties": {
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120",
                 "FunctionName": "SerializeKeyValue",
                 "Handler": "index.myHandler",

--- a/templates/oodle-master.template
+++ b/templates/oodle-master.template
@@ -642,8 +642,7 @@
                 "dc2.large",
                 "dc2.8xlarge",
                 "ds2.xlarge",
-                "ds2.8xlarge",
-                "dc1.large"
+                "ds2.8xlarge"
             ]
         },
 		"RedshiftNumberOfNodes": {

--- a/templates/oodle-master.template
+++ b/templates/oodle-master.template
@@ -642,7 +642,8 @@
                 "dc2.large",
                 "dc2.8xlarge",
                 "ds2.xlarge",
-                "ds2.8xlarge"
+                "ds2.8xlarge",
+                "dc1.large"
             ]
         },
 		"RedshiftNumberOfNodes": {

--- a/templates/oodle-master.template
+++ b/templates/oodle-master.template
@@ -1,1098 +1,939 @@
-{
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This template uses the Talend Server templates with the AWS VPC quickstart.  The AWS VPC creates a multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways in the public subnet for each Availability Zone. The Talend servers are deployed to the public subnet with the exception of the Jobservers which are deployed to the private subnet. **WARNING** This template creates AWS resources. You will be billed for the AWS resources used if you create a stack from this template. (qs-1nrlpbhnf)",
-    "Metadata": {
-        "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [
-                {
-                    "Label": {
-                        "default": "Network configuration"
-                    },
-                    "Parameters": [
-                       	"AvailabilityZones",
-						"VPCCIDR",
-                        "PublicSubnet1CIDR",
-                        "PublicSubnet2CIDR",
-                        "PrivateSubnet1CIDR",
-                        "PrivateSubnet2CIDR",
-                        "RemoteAccessCIDR"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Creation options for existing deployments"
-                    },
-                    "Parameters": [
-                        "CreateDistantRunStack",
-                        "CreateEmr",
-                        "CreateTacDatabase",
-						"CreateStudioStack"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "EC2 Auto Scaling configuration"
-                    },
-                    "Parameters": [
-                        "JobserverAutoscaleDesiredCapacity",
-                        "JobserverAutoscaleMaxSize",
-                        "DistantRunAutoscaleDesiredCapacity",
-                        "DistantRunAutoscaleMaxSize"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Amazon Redshift configuration"
-                    },
-                    "Parameters": [
-                        "RedshiftHost",
-                        "RedshiftUsername",
-                        "RedshiftPassword",
-                        "RedshiftDbName"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Talend Administration Center configuration"
-                    },
-                    "Parameters": [
-                        "TacDbHost",
-                        "MasterDbUser",
-                        "MasterDbPassword",
-                        "TacDbSchema",
-                        "TacUsername",
-                        "TacPassword",
-                        "TacDbUser",
-                        "TacDbPassword",
-                        "DbClass",
-                        "DbAllocatedStorage",
-						"AmcDbUser",
-						"AmcDbPassword",
-                        "TalendResourceBucket",
-                        "TalendLicenseBucket"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Talend Nexus configuration"
-                    },
-                    "Parameters": [
-                        "NexusAdminUserid",
-                        "NexusAdminPassword"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Talend Git configuration"
-                    },
-                    "Parameters": [
-                        "GitProtocol",
-                        "GitHost",
-                        "GitPort",
-                        "GitRepo",
-                        "GitAdminUserid",
-                        "GitAdminPassword",
-                        "GitAdminEmail",
-                        "GitTacUserid",
-                        "GitTacPassword",
-                        "GitTacEmail"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Sizing configuration"
-                    },
-                    "Parameters": [
-                        "KeyPairName",
-                        "TacInstanceType",
-                        "LogserverInstanceType",
-                        "JobserverInstanceType",
-                        "NexusInstanceType",
-						"StudioInstanceType",
-						"GitInstanceType",
-						"BastionInstanceType",
-						"NumBastionHosts",
-						"RedshiftNodeType",
-						"RedshiftNumberOfNodes",
-						"EmrMasterInstanceType",
-						"EmrCoreInstanceType",
-						"EmrCoreNodes"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Quick Start Configuration"
-                    },
-                    "Parameters": [
-                        "QSS3BucketName",
-                        "QSS3KeyPrefix"
-                    ]
-                }
-            ],
-            "ParameterLabels": {
-                "QSS3BucketName": {
-                    "default": "Quick Start S3 Bucket"
-                },
-                "QSS3KeyPrefix": {
-                    "default": "Quick Start S3 Key Prefix (optional)"
-                },
-                "TalendResourceBucket": {
-                    "default": "Talend Resource Bucket"
-                },
-                "TalendLicenseBucket": {
-                    "default": "Talend License Bucket"
-                },
-                "CreateDistantRunStack": {
-                    "default": "Create Distant Run Stack"
-                },
-                "CreateEmr": {
-                    "default": "Create Amazon EMR"
-                },
-                "CreateTacDatabase": {
-                    "default": "Create TAC Database"
-                },
-                "AvailabilityZones": {
-                    "default": "Availability Zones"
-                },
-                "VPCCIDR": {
-                    "default": "VPC CIDR"
-                },
-                "PublicSubnet1CIDR": {
-                    "default": "Public Subnet1 CIDR"
-                },
-                "PublicSubnet2CIDR": {
-                    "default": "Public Subnet2 CIDR"
-                },
-                "PrivateSubnet1CIDR": {
-                    "default": "Private Subnet1 CIDR"
-                },
-                "PrivateSubnet2CIDR": {
-                    "default": "Private Subnet2 CIDR"
-                },
-                "RemoteAccessCIDR": {
-                    "default": "Remote Access CIDR"
-                },
-                "KeyPairName": {
-                    "default": "Key Pair Name"
-                },
-                "TacInstanceType": {
-                    "default": "TAC Instance Type"
-                },
-				"GitInstanceType": {
-                    "default": "Git Instance Type"
-                },
-                "TacDbUser": {
-                    "default": "TAC Database Username"
-                },
-                "TacDbPassword": {
-                    "default": "TAC Database Password"
-                },
-                "TacDbHost": {
-                    "default": "TAC Database Host (optional)"
-                },
-                "TacDbSchema": {
-                    "default": "TAC Database Schema"
-                },
-                "MasterDbUser": {
-                    "default": "TAC Master Database User"
-                },
-                "MasterDbPassword": {
-                    "default": "TAC Master Database Password"
-                },
-                "DbClass": {
-                    "default": "Database Instance Class"
-                },
-                "DbAllocatedStorage": {
-                    "default": "Database Allocated Storage"
-                },
-                "NexusAdminUserid": {
-                    "default": "Nexus Admin User ID"
-                },
-                "NexusAdminPassword": {
-                    "default": "Nexus Admin Password"
-                },
-                "LogserverInstanceType": {
-                    "default": "Logserver Instance Type"
-                },
-                "JobserverInstanceType": {
-                    "default": "Jobserver Instance Type"
-                },
-                "NexusInstanceType": {
-                    "default": "Nexus Instance Type"
-                },
-                "JobserverAutoscaleDesiredCapacity": {
-                    "default": "Jobserver Autoscale Desired Capacity"
-                },
-                "JobserverAutoscaleMaxSize": {
-                    "default": "Jobserver Autoscale Maximum Capacity"
-                },
-                "DistantRunAutoscaleDesiredCapacity": {
-                    "default": "DistantRun Autoscale Desired Capacity"
-                },
-                "DistantRunAutoscaleMaxSize": {
-                    "default": "DistantRun Autoscale Maximum Capacity"
-                },
-                "RedshiftHost": {
-                    "default": "Amazon Redshift Host (optional)"
-                },
-                "RedshiftDbName": {
-                    "default": "Amazon Redshift Database Name"
-                },
-                "RedshiftUsername": {
-                    "default": "Amazon Redshift Username"
-                },
-                "RedshiftPassword": {
-                    "default": "Amazon Redshift Password"
-                },
-                "GitProtocol": {
-                    "default": "Git Protocol"
-                },
-                "GitHost": {
-                    "default": "Git Host (optional)"
-                },
-                "GitPort": {
-                    "default": "Git TCP Port"
-                },
-                "GitRepo": {
-                    "default": "Git Repository"
-                },
-                "GitAdminUserid": {
-                    "default": "Git Admin User ID"
-                },
-                "GitAdminPassword": {
-                    "default": "Git Admin Password"
-                },
-                "GitAdminEmail": {
-                    "default": "Git Admin Email"
-                },
-                "GitTacUserid": {
-                    "default": "Git TAC User ID"
-                },
-                "GitTacPassword": {
-                    "default": "Git TAC Password"
-                },
-                "GitTacEmail": {
-                    "default": "Git TAC Email"
-                },
-                "TacPassword": {
-                    "default": "TAC Password"
-                },
-                "AmcDbUser": {
-                    "default": "AMC Database Username"
-                },
-                "AmcDbPassword": {
-                    "default": "AMC Database Password"
-                },
-                "StudioInstanceType": {
-                    "default": "Studio Instance Type"
-                },
-                "BastionInstanceType": {
-                    "default": "Bastion Instance Type"
-                },
-                "NumBastionHosts": {
-                    "default": "Number of Bastion Hosts"
-                },
-                "RedshiftNodeType": {
-                    "default": "Amazon Redshift Node Type"
-                },
-                "RedshiftNumberOfNodes": {
-                    "default": "Number of Amazon Redshift Nodes"
-                },
-                "EmrMasterInstanceType": {
-                    "default": "Amazon EMR Master Node Instance Type"
-                },
-                "EmrCoreInstanceType": {
-                    "default": "Amazon EMR Core Node Instance Type"
-                },
-                "EmrCoreNodes": {
-                    "default": "Number of Amazon EMR Core Nodes"
-                },
-                "CreateStudioStack": {
-                    "default": "Create Studio Stack"
-                }
-            }
-        }
-    },
-    "Parameters": {
-        "QSS3BucketName": {
-            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$",
-            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-) or period (.).",
-            "Default": "aws-quickstart",
-            "Description": "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-) or period (.).",
-            "Type": "String"
-        },
-        "QSS3KeyPrefix": {
-            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
-            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).  Prefix cannot start with a slash but must end with a slash unless it is the empty string.",
-            "Default": "quickstart-datalake-cognizant-talend/",
-            "Description": "The S3 key name prefix used to simulate a folder for your copy of Quick Start assets, if you decide to customize or extend the Quick Start for your own use. This prefix can include numbers, lowercase letters, uppercase letters, hyphens, and forward slashes",
-            "Type": "String"
-        },
-        "TalendLicenseBucket": {
-            "Description": "Bucket holding Talend license",
-            "Type": "String",
-            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$",
-            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-) or period (.)."
-        },
-        "TalendResourceBucket": {
-            "Description": "Talend S3 resources bucket.",
-            "Type": "String",
-            "Default": "repo-quickstart-talend"
-        },
-        "TacInstanceType": {
-            "Description": "EC2 instance type for the Talend Administration Center",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "x1.16xlarge",
-                "x1.32xlarge",
-                "x1e.32xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "GitInstanceType": {
-            "Description": "EC2 Instance type for Git Server",
-            "Type": "String",
-            "Default": "m4.large",
-            "AllowedValues": [
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "NexusInstanceType": {
-            "Description": "EC2 Instance type for Nexus Server",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "LogserverInstanceType": {
-            "Description": "EC2 Instance type for Log Server",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "JobserverInstanceType": {
-            "Description": "EC2 Instance type for Talend Jobservers",
-            "Type": "String",
-            "Default": "t2.large",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "x1.16xlarge",
-                "x1.32xlarge",
-                "x1e.32xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "StudioInstanceType": {
-            "Description": "EC2 Instance type for Talend Studio",
-            "Type": "String",
-            "Default": "m4.xlarge",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "BastionInstanceType": {
-            "Description": "EC2 Instance type for Bastion host",
-            "Type": "String",
-            "Default": "t2.micro",
-            "AllowedValues": [
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m3.large",
-                "m3.xlarge",
-                "m3.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge"
-            ]
-        },
-        "CreateEmr": {
-            "Description": "Set this to true to create a new EMR instance. If you do not wish to use EMR or want to use an existing EMR, set this to false.",
-            "Type": "String",
-            "Default": "true",
-            "AllowedValues": [
-                "true",
-                "false"
-            ]
-        },
-        "CreateDistantRunStack": {
-            "Description": "Set this to true to create Talend Jobserver autoscale group in public subnet for remote job submission from Talend Studio. If you do not wish to use DistantRun, set this to false.",
-            "Type": "String",
-			"Default": "true",
-            "AllowedValues": [ "true", "false" ]
-        },
-        "CreateTacDatabase": {
-            "Description": "Set this to true to create a new Talend Administration Center (TAC) database. If you do not wish to use TAC or want to use an existing database, set this to false.",
-            "Type": "String",
-            "AllowedValues": [ "true", "false" ],
-            "Default": "true"
-        },
-        "CreateStudioStack": {
-            "Description": "Set this to true to create Talend Studio EC2 instance in the public subnet. If you do not wish to use Talend Studiot, set this to false.",
-            "Type": "String",
-			"Default": "true",
-            "AllowedValues": [ "true", "false" ]
-        },
-        "NexusAdminUserid": {
-            "Description": "Administrator User Id for Nexus Server",
-            "Type": "String",
-            "Default": "admin"
-        },
-        "NexusAdminPassword": {
-            "Description": "Password for Nexus Server",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "TacDbHost": {
-            "Description": "Name or IP address of host on which an existing MySQL database runs which you intend to use as the TAC database. Leave this blank to create a new MySQL database for TAC.",
-            "Type": "String",
-            "Default": ""
-        },
-        "TacPassword": {
-            "Description": "TAC application password for tadmin account.",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "MasterDbUser": {
-            "Description": "The master or root user used to create TAC and AMC databases and the TAC user.  Only needed if creating the TAC or AMC databases",
-            "Type": "String",
-            "Default": "tadmin"
-        },
-        "MasterDbPassword": {
-            "Description": "Master user database password.  Only needed if creating the TAC or AMC databases.",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "TacDbSchema": {
-            "Description": "Existing Database schema for Talend Administration Center (TAC)",
-            "Type": "String",
-            "Default": "tac_quickstart"
-        },
-        "TacDbUser": {
-            "Description": "Existing Database Username for TAC",
-            "Type": "String",
-            "Default": "tac"
-        },
-        "TacDbPassword": {
-            "Description": "Existing Database Password for TAC",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "AmcDbUser": {
-            "Description": "Database user name for Activity Monitoring console (AMC)",
-            "Type": "String",
-            "Default": "amc"
-        },
-        "AmcDbPassword": {
-            "Description": "Database Password for AMC",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "DbClass": {
-            "Description": "Instance class of RDS instance",
-            "Type": "String",
-            "AllowedValues": [ "db.t2.micro", "db.t2.small", "db.t2.medium", "db.t2.large", "db.m4.large", "db.m4.xlarge", "db.m4.2xlarge", "db.m4.4xlarge", "db.m4.10xlarge", "db.r3.large", "db.r3.xlarge", "db.r3.2xlarge", "db.r3.4xlarge", "db.r3.8xlarge" ],
-            "Default": "db.t2.medium"
-        },
-        "DbAllocatedStorage": {
-            "Description": "Allocated Storage (in GB) for RDS instance",
-            "Type": "Number",
-            "Default": "20"
-        },
-        "RedshiftHost": {
-            "Description": "DNS Name or IP address of the master node of an existing Redshift cluster which you intend to use for the Talend sample jobs. Leave this blank to create a new Redshift cluster.",
-            "Type": "String",
-            "Default": ""
-        },
-		"RedshiftUsername": {
-            "Description": "User name for Redshift database",
-            "Type": "String",
-            "Default": "tadmin"
-        },
-        "RedshiftPassword": {
-            "Description": "Password for Redshift. Can only contain alphanumeric characters or the following special characters!^*-_+",
-            "NoEcho": true,
-            "Type": "String",
-			"MinLength": 8,
-            "MaxLength": 28,
-            "AllowedPattern": "[a-zA-Z0-9!^*\\-_+]*"
-        },
-		"RedshiftDbName": {
-            "Description": "Database name for Redshift",
-            "Type": "String",
-            "Default": ""
-        },
-		"RedshiftNodeType": {
-            "Type": "String",
-            "Default": "dc2.large",
-            "Description": "EC2 instance type for the Redshift cluster nodes",
-            "ConstraintDescription": "must be a valid RedShift node type.",
-            "AllowedValues": [
-                "dc2.large",
-                "dc2.8xlarge",
-                "ds2.xlarge",
-                "ds2.8xlarge"
-            ]
-        },
-		"RedshiftNumberOfNodes": {
-            "Description": "The number of nodes in the Redshift cluster.",
-            "Type": "Number",
-            "Default": "1"
-        },
-		"EmrMasterInstanceType": {
-            "AllowedValues": [
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "Default": "c4.xlarge",
-            "Description": "Instance type for the EMR master node.",
-            "Type": "String"
-        },
-		"EmrCoreInstanceType": {
-            "AllowedValues": [
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "Default": "c4.xlarge",
-            "Description": "Instance type for the EMR core nodes.",
-            "Type": "String"
-        },
-		"EmrCoreNodes": {
-            "Description": "Number of EMR Core Nodes. Minimum 1",
-            "MaxValue": "500",
-            "MinValue": "1",
-            "Type": "Number",
-			"Default": "2"
-        },
-        "JobserverAutoscaleMaxSize": {
-            "Description": "Maximum no. of EC2 instances for Talend Jobserver autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "5"
-        },
-        "JobserverAutoscaleDesiredCapacity": {
-            "Description": "Desired no. of EC2 instances for Talend Jobserver autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "1"
-        },
-        "DistantRunAutoscaleMaxSize": {
-            "Description": "Maximum no. of EC2 instances for Talend DistantRun Autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "5"
-        },
-        "DistantRunAutoscaleDesiredCapacity": {
-            "Description": "Desired no. of EC2 instances for Talend DistantRun Autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "1"
-        },
-        "GitProtocol": {
-            "Description": "Git protocol.",
-            "Type": "String",
-            "Default": "http"
-        },
-        "GitHost": {
-            "Description": "Host name of Git",
-            "Type": "String",
-            "Default": ""
-        },
-        "GitPort": {
-            "Description": "Port number of GIT",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "65535",
-            "Default": "80"
-        },
-        "GitRepo": {
-            "Description": "Name of Git repository.",
-            "Type": "String",
-            "Default": "oodlejobs"
-        },
-        "GitAdminUserid": {
-            "Description": "Unique user Id of Git administrator, must be different than GitTacUserid",
-            "Type": "String",
-            "Default": "tadmin"
-        },
-        "GitAdminPassword": {
-            "Description": "Password for GIT administrator",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "GitAdminEmail": {
-            "Description": "Unique email address of Git administrator, must be different than GitTacEmail",
-            "Type": "String",
-            "Default": ""
-        },
-        "GitTacUserid": {
-            "Description": "Unique user id for GIT TAC, must be different than GitAdminUserid",
-            "Type": "String",
-            "Default": "tac"
-        },
-        "GitTacPassword": {
-            "Description": "Password for GIT TAC",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "GitTacEmail": {
-            "Description": "Unique contact email address for TAC, must be different than GitAdminEmail",
-            "Type": "String",
-            "Default": ""
-        },
-        "NumBastionHosts": {
-            "AllowedValues": [ "0", "1", "2" ],
-            "Default": "1",
-            "Description": "The number of Linux bastion hosts to run. Auto Scaling will ensure that you always have this number of bastion hosts running.",
-            "Type": "String"
-        },
-        "AvailabilityZones": {
-            "Description": "Select two Availability Zones that will be used to deploy the CloudFormation stacks. The Quick Start preserves the logical order you specify.",
-            "Type": "List<AWS::EC2::AvailabilityZone::Name>"
-        },
-        "KeyPairName": {
-            "Description": "Public/private key pair, which allows you to connect securely to your instance after it launches. When you created an AWS account, this is the key pair you created in your preferred region.",
-            "Type": "AWS::EC2::KeyPair::KeyName"
-        },
-        "PrivateSubnet1CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
-            "Default": "10.0.0.0/19",
-            "Description": "CIDR block for private subnet 1 located in Availability Zone 1.",
-            "Type": "String"
-        },
-        "PrivateSubnet2CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
-            "Default": "10.0.32.0/19",
-            "Description": "CIDR block for private subnet 2 located in Availability Zone 2.",
-            "Type": "String"
-        },
-        "PublicSubnet1CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
-            "Default": "10.0.128.0/20",
-            "Description": "CIDR Block for the public DMZ subnet 1 located in Availability Zone 1",
-            "Type": "String"
-        },
-        "PublicSubnet2CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
-            "Default": "10.0.144.0/20",
-            "Description": "CIDR Block for the public DMZ subnet 2 located in Availability Zone 2",
-            "Type": "String"
-        },
-        "RemoteAccessCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
-            "Description": "The CIDR IP range that is permitted to access the VPC. We recommend that you use a constrained CIDR range to reduce the potential of inbound attacks from unknown IP addresses. For example, if your IPv4 address is 203.0.113.25, specify 203.0.113.25/32 to list this single IPv4 address in CIDR notation. If your company allocates addresses from a range, specify the entire range, such as 203.0.113.0/24. For details, see VPCs and Subnets in the AWS documentation.",
-            "Type": "String"
-        },
-        "VPCCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
-            "ConstraintDescription": "CIDR block for the VPC. When you create a VPC, you must specify a range of IPv4 addresses for the VPC in the form of a Classless Inter-Domain Routing (CIDR) block. You can also optionally assign an IPv6 CIDR block to your VPC, and assign IPv6 CIDR blocks to your subnets.",
-            "Default": "10.0.0.0/16",
-            "Description": "CIDR Block for the VPC",
-            "Type": "String"
-        }
-    },
-    "Mappings": {
-        "Talend": {
-            "flags": {
-                "SaveCredentialsEnabled": "true"
-            }
-        }
-    },
-    "Conditions": {
-        "CreateRdsCondition": { 
-            "Fn::Equals": [ "", { "Ref": "TacDbHost" } ]
-        },
-        "CreateGitCondition": {
-            "Fn::Equals": [ "", { "Ref": "GitHost" } ]
-        },
-        "CreateRedshiftCondition": {
-            "Fn::Equals": [ "", { "Ref": "RedshiftHost" } ]
-        },
-        "CreateEmrCondition": {
-            "Fn::Equals": [ "true", { "Ref": "CreateEmr" } ]
-        },
-        "CreateStudioCondition": {
-            "Fn::Equals": [
-                { "Ref": "CreateStudioStack" },
-                "true"
-            ]
-        },
-        "CreateBastionCondition": {
-            "Fn::Not": [
-                { "Fn::Equals": [ { "Ref": "NumBastionHosts" }, "0" ] }
-            ]
-        }
-    },
-    "Resources": {
-        "VpcStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/bastion/submodules/quickstart-aws-vpc/templates/aws-vpc.template" },
-                "Parameters": {
-                    "AvailabilityZones": {
-                        "Fn::Join": [ ",", { "Ref": "AvailabilityZones" } ]
-                    },
-                    "KeyPairName": { "Ref": "KeyPairName" },
-                    "NumberOfAZs": "2",
-                    "PrivateSubnet1ACIDR": { "Ref": "PrivateSubnet1CIDR" },
-                    "PrivateSubnet2ACIDR": { "Ref": "PrivateSubnet2CIDR" },
-                    "PublicSubnet1CIDR": { "Ref": "PublicSubnet1CIDR" },
-                    "PublicSubnet2CIDR": { "Ref": "PublicSubnet2CIDR" },
-                    "VPCCIDR": { "Ref": "VPCCIDR" }
-                }
-            }
-        },
-
-        "OodleStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/oodle.template" },
-                "Parameters": {
-                    "QSS3BucketName": { "Ref": "QSS3BucketName" },
-                    "QSS3KeyPrefix": { "Ref": "QSS3KeyPrefix" },
-                    "KeyPairName": { "Ref": "KeyPairName" },
-
-                    "TalendLicenseBucket": { "Ref": "TalendLicenseBucket" },
-                    "TalendResourceBucket": { "Ref": "TalendResourceBucket" },
-
-                    "VpcId": { "Fn::GetAtt": [ "VpcStack", "Outputs.VPCID" ] },
-                    "PublicSubnetId1": { "Fn::GetAtt": [ "VpcStack", "Outputs.PublicSubnet1ID"] },
-                    "PublicSubnetId2": { "Fn::GetAtt": [ "VpcStack", "Outputs.PublicSubnet2ID"] },
-                    "PrivateSubnetId1": { "Fn::GetAtt": [ "VpcStack", "Outputs.PrivateSubnet1AID"] },
-                    "PrivateSubnetId2": { "Fn::GetAtt": [ "VpcStack", "Outputs.PrivateSubnet2AID"] },
-                    "RemoteAccessCIDR": { "Ref": "RemoteAccessCIDR" },
-
-                    "TacInstanceType": { "Ref": "TacInstanceType" },
-                    "GitInstanceType": { "Ref": "GitInstanceType" },
-                    "NexusInstanceType": { "Ref": "NexusInstanceType" },
-                    "LogserverInstanceType": { "Ref": "LogserverInstanceType" },
-                    "JobserverInstanceType": { "Ref": "JobserverInstanceType" },
-                    "StudioInstanceType": { "Ref": "StudioInstanceType" },
-                    "BastionInstanceType": { "Ref": "BastionInstanceType" },
-
-                    "CreateEmr": { "Ref": "CreateEmr" },
-                    "CreateDistantRunStack": { "Ref": "CreateDistantRunStack" },
-                    "CreateTacDatabase": { "Ref": "CreateTacDatabase" },
-                    "CreateStudioStack": { "Ref": "CreateStudioStack" },
-
-                    "NexusAdminUserid": { "Ref": "NexusAdminUserid" },
-                    "NexusAdminPassword": { "Ref": "NexusAdminPassword" },
-
-                    "TacDbHost": { "Ref": "TacDbHost" },
-                    "TacPassword": { "Ref": "TacPassword" },
-                    "MasterDbUser": { "Ref": "MasterDbUser" },
-                    "MasterDbPassword": { "Ref": "MasterDbPassword" },
-                    "TacDbSchema": { "Ref": "TacDbSchema" },
-                    "TacDbUser": { "Ref": "TacDbUser" },
-                    "TacDbPassword": { "Ref": "TacDbPassword" },
-                    "AmcDbUser": { "Ref": "AmcDbUser" },
-                    "AmcDbPassword": { "Ref": "AmcDbPassword" },
-
-                    "DbClass": { "Ref": "DbClass" },
-                    "DbAllocatedStorage": { "Ref": "DbAllocatedStorage" },
-
-                    "RedshiftHost": { "Ref": "RedshiftHost" },
-                    "RedshiftUsername": { "Ref": "RedshiftUsername" },
-                    "RedshiftPassword": { "Ref": "RedshiftPassword" },
-                    "RedshiftDbName": { "Ref": "RedshiftDbName" },
-                    "RedshiftNodeType": { "Ref": "RedshiftNodeType" },
-                    "RedshiftNumberOfNodes": { "Ref": "RedshiftNumberOfNodes" },
-
-                    "EmrMasterInstanceType": { "Ref": "EmrMasterInstanceType" },
-                    "EmrCoreInstanceType": { "Ref": "EmrCoreInstanceType" },
-                    "EmrCoreNodes": { "Ref": "EmrCoreNodes" },
-
-                    "JobserverAutoscaleMaxSize": { "Ref": "JobserverAutoscaleMaxSize" },
-                    "JobserverAutoscaleDesiredCapacity": { "Ref": "JobserverAutoscaleDesiredCapacity" },
-                    "DistantRunAutoscaleMaxSize": { "Ref": "DistantRunAutoscaleMaxSize" },
-                    "DistantRunAutoscaleDesiredCapacity": { "Ref": "DistantRunAutoscaleDesiredCapacity" },
-
-                    "GitProtocol": { "Ref": "GitProtocol" },
-                    "GitHost": { "Ref": "GitHost" },
-                    "GitPort": { "Ref": "GitPort" },
-                    "GitRepo": { "Ref": "GitRepo" },
-                    "GitAdminUserid": { "Ref": "GitAdminUserid" },
-                    "GitAdminPassword": { "Ref": "GitAdminPassword" },
-                    "GitAdminEmail": { "Ref": "GitAdminEmail" },
-                    "GitTacUserid": { "Ref": "GitTacUserid" },
-                    "GitTacPassword": { "Ref": "GitTacPassword" },
-                    "GitTacEmail": { "Ref": "GitTacEmail" },
-
-                    "NumBastionHosts": { "Ref": "NumBastionHosts"  }
-                }
-            }
-        }
-    },
-    "Outputs": {
-        "VpcStack": {
-            "Value": { "Ref": "VpcStack" },
-            "Description": "Nested VPC stack",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:VpcStack" } 
-				} 
-        },
-        "OodleStack": {
-            "Value": { "Ref": "OodleStack" },
-            "Description": "Nested Oodle stack",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:OodleStack" } 
-				} 
-        },
-        "GitPublicDnsName": {
-            "Value": { 
-                "Fn::If": [
-                    "CreateGitCondition",
-                    { "Fn::GetAtt": [ "OodleStack", "Outputs.GitPublicDnsName" ] },
-                    { "Ref": "GitHost" } 
-                ]
-            },
-            "Description": "Git DNS",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:GitPublicDnsName" } 
-			}
-        },		
-        "TacPublicDnsName": {
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.TacPublicDnsName"] },
-            "Description": "TAC public DNS",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TacPublicDnsName" } 
-			}
-        },
-        "NexusPublicDnsName": {
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.NexusPublicDnsName"] },
-            "Description": "Nexus public DNS",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:NexusPublicDnsName" } 
-			}
-        },	
-        "StudioPublicDnsName": {
-            "Condition": "CreateStudioCondition",			
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.StudioPublicDnsName"] },
-            "Description": "Studio public URL",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:StudioPublicDnsName" } 
-			}
-        },		
-        "RedshiftJDBC": {
-            "Condition": "CreateRedshiftCondition",		
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.RedshiftJDBC"] },
-            "Description": "Redshift JDBC Url",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:RedshiftJDBC" } 
-			}
-        },
-		"RedshiftEndpoint": {
-            "Condition": "CreateRedshiftCondition",		
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.RedshiftEndpoint"] },
-            "Description": "Redshift Endpoint",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:RedshiftEndpoint" } 
-			}
-        },
-		"EmrMasterPublicDns": {
-            "Condition": "CreateEmrCondition",		
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.EmrMasterPublicDns"] },
-            "Description": "EMR public DNS",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:EmrMasterPublicDns" } 
-			}
-        },
-		"CredentialBucket": {	
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.CredentialBucket"] },
-            "Description": "Talend Credential Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:CredentialBucket" } 
-			}
-        },		
-		"TalendSourceBucket": {	
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.TalendSourceBucket"] },
-            "Description": "Talend Source Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TalendSourceBucket" } 
-			}
-        },	
-		"TalendTargetBucket": {	
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.TalendTargetBucket"] },
-            "Description": "Talend Target Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TalendTargetBucket" } 
-			}
-        },	
-		"EmrLogBucket": {
-            "Condition": "CreateEmrCondition",		
-            "Value": { "Fn::GetAtt": [ "OodleStack", "Outputs.EmrLogBucket"] },
-            "Description": "Emr Log Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:EmrLogBucket" } 
-			}
-        }		
-    }
-}
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  This template uses the Talend Server templates with the AWS VPC quickstart.  The
+  AWS VPC creates a multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways
+  in the public subnet for each Availability Zone. The Talend servers are deployed
+  to the public subnet with the exception of the Jobservers which are deployed to
+  the private subnet. **WARNING** This template creates AWS resources. You will be
+  billed for the AWS resources used if you create a stack from this template. (qs-1nrlpbhnf)
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network configuration
+        Parameters:
+          - AvailabilityZones
+          - VPCCIDR
+          - PublicSubnet1CIDR
+          - PublicSubnet2CIDR
+          - PrivateSubnet1CIDR
+          - PrivateSubnet2CIDR
+          - RemoteAccessCIDR
+      - Label:
+          default: Creation options for existing deployments
+        Parameters:
+          - CreateDistantRunStack
+          - CreateEmr
+          - CreateTacDatabase
+          - CreateStudioStack
+      - Label:
+          default: EC2 Auto Scaling configuration
+        Parameters:
+          - JobserverAutoscaleDesiredCapacity
+          - JobserverAutoscaleMaxSize
+          - DistantRunAutoscaleDesiredCapacity
+          - DistantRunAutoscaleMaxSize
+      - Label:
+          default: Amazon Redshift configuration
+        Parameters:
+          - RedshiftHost
+          - RedshiftUsername
+          - RedshiftPassword
+          - RedshiftDbName
+      - Label:
+          default: Talend Administration Center configuration
+        Parameters:
+          - TacDbHost
+          - MasterDbUser
+          - MasterDbPassword
+          - TacDbSchema
+          - TacUsername
+          - TacPassword
+          - TacDbUser
+          - TacDbPassword
+          - DbClass
+          - DbAllocatedStorage
+          - AmcDbUser
+          - AmcDbPassword
+          - TalendResourceBucket
+          - TalendLicenseBucket
+      - Label:
+          default: Talend Nexus configuration
+        Parameters:
+          - NexusAdminUserid
+          - NexusAdminPassword
+      - Label:
+          default: Talend Git configuration
+        Parameters:
+          - GitProtocol
+          - GitHost
+          - GitPort
+          - GitRepo
+          - GitAdminUserid
+          - GitAdminPassword
+          - GitAdminEmail
+          - GitTacUserid
+          - GitTacPassword
+          - GitTacEmail
+      - Label:
+          default: Sizing configuration
+        Parameters:
+          - KeyPairName
+          - TacInstanceType
+          - LogserverInstanceType
+          - JobserverInstanceType
+          - NexusInstanceType
+          - StudioInstanceType
+          - GitInstanceType
+          - BastionInstanceType
+          - NumBastionHosts
+          - RedshiftNodeType
+          - RedshiftNumberOfNodes
+          - EmrMasterInstanceType
+          - EmrCoreInstanceType
+          - EmrCoreNodes
+      - Label:
+          default: Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+    ParameterLabels:
+      QSS3BucketName:
+        default: Quick Start S3 Bucket
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix (optional)
+      TalendResourceBucket:
+        default: Talend Resource Bucket
+      TalendLicenseBucket:
+        default: Talend License Bucket
+      CreateDistantRunStack:
+        default: Create Distant Run Stack
+      CreateEmr:
+        default: Create Amazon EMR
+      CreateTacDatabase:
+        default: Create TAC Database
+      AvailabilityZones:
+        default: Availability Zones
+      VPCCIDR:
+        default: VPC CIDR
+      PublicSubnet1CIDR:
+        default: Public Subnet1 CIDR
+      PublicSubnet2CIDR:
+        default: Public Subnet2 CIDR
+      PrivateSubnet1CIDR:
+        default: Private Subnet1 CIDR
+      PrivateSubnet2CIDR:
+        default: Private Subnet2 CIDR
+      RemoteAccessCIDR:
+        default: Remote Access CIDR
+      KeyPairName:
+        default: Key Pair Name
+      TacInstanceType:
+        default: TAC Instance Type
+      GitInstanceType:
+        default: Git Instance Type
+      TacDbUser:
+        default: TAC Database Username
+      TacDbPassword:
+        default: TAC Database Password
+      TacDbHost:
+        default: TAC Database Host (optional)
+      TacDbSchema:
+        default: TAC Database Schema
+      MasterDbUser:
+        default: TAC Master Database User
+      MasterDbPassword:
+        default: TAC Master Database Password
+      DbClass:
+        default: Database Instance Class
+      DbAllocatedStorage:
+        default: Database Allocated Storage
+      NexusAdminUserid:
+        default: Nexus Admin User ID
+      NexusAdminPassword:
+        default: Nexus Admin Password
+      LogserverInstanceType:
+        default: Logserver Instance Type
+      JobserverInstanceType:
+        default: Jobserver Instance Type
+      NexusInstanceType:
+        default: Nexus Instance Type
+      JobserverAutoscaleDesiredCapacity:
+        default: Jobserver Autoscale Desired Capacity
+      JobserverAutoscaleMaxSize:
+        default: Jobserver Autoscale Maximum Capacity
+      DistantRunAutoscaleDesiredCapacity:
+        default: DistantRun Autoscale Desired Capacity
+      DistantRunAutoscaleMaxSize:
+        default: DistantRun Autoscale Maximum Capacity
+      RedshiftHost:
+        default: Amazon Redshift Host (optional)
+      RedshiftDbName:
+        default: Amazon Redshift Database Name
+      RedshiftUsername:
+        default: Amazon Redshift Username
+      RedshiftPassword:
+        default: Amazon Redshift Password
+      GitProtocol:
+        default: Git Protocol
+      GitHost:
+        default: Git Host (optional)
+      GitPort:
+        default: Git TCP Port
+      GitRepo:
+        default: Git Repository
+      GitAdminUserid:
+        default: Git Admin User ID
+      GitAdminPassword:
+        default: Git Admin Password
+      GitAdminEmail:
+        default: Git Admin Email
+      GitTacUserid:
+        default: Git TAC User ID
+      GitTacPassword:
+        default: Git TAC Password
+      GitTacEmail:
+        default: Git TAC Email
+      TacPassword:
+        default: TAC Password
+      AmcDbUser:
+        default: AMC Database Username
+      AmcDbPassword:
+        default: AMC Database Password
+      StudioInstanceType:
+        default: Studio Instance Type
+      BastionInstanceType:
+        default: Bastion Instance Type
+      NumBastionHosts:
+        default: Number of Bastion Hosts
+      RedshiftNodeType:
+        default: Amazon Redshift Node Type
+      RedshiftNumberOfNodes:
+        default: Number of Amazon Redshift Nodes
+      EmrMasterInstanceType:
+        default: Amazon EMR Master Node Instance Type
+      EmrCoreInstanceType:
+        default: Amazon EMR Core Node Instance Type
+      EmrCoreNodes:
+        default: Number of Amazon EMR Core Nodes
+      CreateStudioStack:
+        default: Create Studio Stack
+Parameters:
+  QSS3BucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, periods (.), and hyphens (-). It cannot start or
+      end with a hyphen (-) or period (.).
+    Default: aws-quickstart
+    Description: >-
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include
+      numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-).
+      It cannot start or end with a hyphen (-) or period (.).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: >-
+      Quick Start key prefix can include numbers, lowercase letters, uppercase letters,
+      hyphens (-), and forward slash (/).  Prefix cannot start with a slash but must
+      end with a slash unless it is the empty string.
+    Default: quickstart-datalake-cognizant-talend/
+    Description: >-
+      The S3 key name prefix used to simulate a folder for your copy of Quick Start
+      assets, if you decide to customize or extend the Quick Start for your own use.
+      This prefix can include numbers, lowercase letters, uppercase letters, hyphens,
+      and forward slashes
+    Type: String
+  TalendLicenseBucket:
+    Description: Bucket holding Talend license
+    Type: String
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, periods (.), and hyphens (-). It cannot start or
+      end with a hyphen (-) or period (.).
+  TalendResourceBucket:
+    Description: Talend S3 resources bucket.
+    Type: String
+    Default: repo-quickstart-talend
+  TacInstanceType:
+    Description: EC2 instance type for the Talend Administration Center
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.32xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  GitInstanceType:
+    Description: EC2 Instance type for Git Server
+    Type: String
+    Default: m4.large
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  NexusInstanceType:
+    Description: EC2 Instance type for Nexus Server
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  LogserverInstanceType:
+    Description: EC2 Instance type for Log Server
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  JobserverInstanceType:
+    Description: EC2 Instance type for Talend Jobservers
+    Type: String
+    Default: t2.large
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.32xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  StudioInstanceType:
+    Description: EC2 Instance type for Talend Studio
+    Type: String
+    Default: m4.xlarge
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  BastionInstanceType:
+    Description: EC2 Instance type for Bastion host
+    Type: String
+    Default: t2.micro
+    AllowedValues:
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+  CreateEmr:
+    Description: Set this to true to create a new EMR instance. If you do not wish
+      to use EMR or want to use an existing EMR, set this to false.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  CreateDistantRunStack:
+    Description: Set this to true to create Talend Jobserver autoscale group in public
+      subnet for remote job submission from Talend Studio. If you do not wish to use
+      DistantRun, set this to false.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  CreateTacDatabase:
+    Description: Set this to true to create a new Talend Administration Center (TAC)
+      database. If you do not wish to use TAC or want to use an existing database,
+      set this to false.
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+  CreateStudioStack:
+    Description: Set this to true to create Talend Studio EC2 instance in the public
+      subnet. If you do not wish to use Talend Studiot, set this to false.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  NexusAdminUserid:
+    Description: Administrator User Id for Nexus Server
+    Type: String
+    Default: admin
+  NexusAdminPassword:
+    Description: Password for Nexus Server
+    Type: String
+    NoEcho: 'true'
+  TacDbHost:
+    Description: Name or IP address of host on which an existing MySQL database runs
+      which you intend to use as the TAC database. Leave this blank to create a new
+      MySQL database for TAC.
+    Type: String
+    Default: ''
+  TacPassword:
+    Description: TAC application password for tadmin account.
+    Type: String
+    NoEcho: 'true'
+  MasterDbUser:
+    Description: The master or root user used to create TAC and AMC databases and
+      the TAC user.  Only needed if creating the TAC or AMC databases
+    Type: String
+    Default: tadmin
+  MasterDbPassword:
+    Description: Master user database password.  Only needed if creating the TAC or
+      AMC databases.
+    Type: String
+    NoEcho: 'true'
+  TacDbSchema:
+    Description: Existing Database schema for Talend Administration Center (TAC)
+    Type: String
+    Default: tac_quickstart
+  TacDbUser:
+    Description: Existing Database Username for TAC
+    Type: String
+    Default: tac
+  TacDbPassword:
+    Description: Existing Database Password for TAC
+    Type: String
+    NoEcho: 'true'
+  AmcDbUser:
+    Description: Database user name for Activity Monitoring console (AMC)
+    Type: String
+    Default: amc
+  AmcDbPassword:
+    Description: Database Password for AMC
+    Type: String
+    NoEcho: 'true'
+  DbClass:
+    Description: Instance class of RDS instance
+    Type: String
+    AllowedValues:
+      - db.t2.micro
+      - db.t2.small
+      - db.t2.medium
+      - db.t2.large
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.r3.large
+      - db.r3.xlarge
+      - db.r3.2xlarge
+      - db.r3.4xlarge
+      - db.r3.8xlarge
+    Default: db.t2.medium
+  DbAllocatedStorage:
+    Description: Allocated Storage (in GB) for RDS instance
+    Type: Number
+    Default: '20'
+  RedshiftHost:
+    Description: DNS Name or IP address of the master node of an existing Redshift
+      cluster which you intend to use for the Talend sample jobs. Leave this blank
+      to create a new Redshift cluster.
+    Type: String
+    Default: ''
+  RedshiftUsername:
+    Description: User name for Redshift database
+    Type: String
+    Default: tadmin
+  RedshiftPassword:
+    Description: Password for Redshift. Can only contain alphanumeric characters or
+      the following special characters!^*-_+
+    NoEcho: true
+    Type: String
+    MinLength: 8
+    MaxLength: 28
+    AllowedPattern: '[a-zA-Z0-9!^*\-_+]*'
+  RedshiftDbName:
+    Description: Database name for Redshift
+    Type: String
+    Default: ''
+  RedshiftNodeType:
+    Type: String
+    Default: dc2.large
+    Description: EC2 instance type for the Redshift cluster nodes
+    ConstraintDescription: must be a valid RedShift node type.
+    AllowedValues:
+      - dc2.large
+      - dc2.8xlarge
+      - ds2.xlarge
+      - ds2.8xlarge
+  RedshiftNumberOfNodes:
+    Description: The number of nodes in the Redshift cluster.
+    Type: Number
+    Default: '1'
+  EmrMasterInstanceType:
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    Default: c4.xlarge
+    Description: Instance type for the EMR master node.
+    Type: String
+  EmrCoreInstanceType:
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    Default: c4.xlarge
+    Description: Instance type for the EMR core nodes.
+    Type: String
+  EmrCoreNodes:
+    Description: Number of EMR Core Nodes. Minimum 1
+    MaxValue: '500'
+    MinValue: '1'
+    Type: Number
+    Default: '2'
+  JobserverAutoscaleMaxSize:
+    Description: Maximum no. of EC2 instances for Talend Jobserver autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '5'
+  JobserverAutoscaleDesiredCapacity:
+    Description: Desired no. of EC2 instances for Talend Jobserver autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '1'
+  DistantRunAutoscaleMaxSize:
+    Description: Maximum no. of EC2 instances for Talend DistantRun Autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '5'
+  DistantRunAutoscaleDesiredCapacity:
+    Description: Desired no. of EC2 instances for Talend DistantRun Autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '1'
+  GitProtocol:
+    Description: Git protocol.
+    Type: String
+    Default: http
+  GitHost:
+    Description: Host name of Git
+    Type: String
+    Default: ''
+  GitPort:
+    Description: Port number of GIT
+    Type: Number
+    MinValue: '1'
+    MaxValue: '65535'
+    Default: '80'
+  GitRepo:
+    Description: Name of Git repository.
+    Type: String
+    Default: oodlejobs
+  GitAdminUserid:
+    Description: Unique user Id of Git administrator, must be different than GitTacUserid
+    Type: String
+    Default: tadmin
+  GitAdminPassword:
+    Description: Password for GIT administrator
+    Type: String
+    NoEcho: 'true'
+  GitAdminEmail:
+    Description: Unique email address of Git administrator, must be different than
+      GitTacEmail
+    Type: String
+    Default: ''
+  GitTacUserid:
+    Description: Unique user id for GIT TAC, must be different than GitAdminUserid
+    Type: String
+    Default: tac
+  GitTacPassword:
+    Description: Password for GIT TAC
+    Type: String
+    NoEcho: 'true'
+  GitTacEmail:
+    Description: Unique contact email address for TAC, must be different than GitAdminEmail
+    Type: String
+    Default: ''
+  NumBastionHosts:
+    AllowedValues:
+      - '0'
+      - '1'
+      - '2'
+    Default: '1'
+    Description: The number of Linux bastion hosts to run. Auto Scaling will ensure
+      that you always have this number of bastion hosts running.
+    Type: String
+  AvailabilityZones:
+    Description: Select two Availability Zones that will be used to deploy the CloudFormation
+      stacks. The Quick Start preserves the logical order you specify.
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+  KeyPairName:
+    Description: Public/private key pair, which allows you to connect securely to
+      your instance after it launches. When you created an AWS account, this is the
+      key pair you created in your preferred region.
+    Type: AWS::EC2::KeyPair::KeyName
+  PrivateSubnet1CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/19
+    Description: CIDR block for private subnet 1 located in Availability Zone 1.
+    Type: String
+  PrivateSubnet2CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.32.0/19
+    Description: CIDR block for private subnet 2 located in Availability Zone 2.
+    Type: String
+  PublicSubnet1CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.128.0/20
+    Description: CIDR Block for the public DMZ subnet 1 located in Availability Zone
+      1
+    Type: String
+  PublicSubnet2CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.144.0/20
+    Description: CIDR Block for the public DMZ subnet 2 located in Availability Zone
+      2
+    Type: String
+  RemoteAccessCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: >-
+      The CIDR IP range that is permitted to access the VPC. We recommend that you
+      use a constrained CIDR range to reduce the potential of inbound attacks from
+      unknown IP addresses. For example, if your IPv4 address is 203.0.113.25, specify
+      203.0.113.25/32 to list this single IPv4 address in CIDR notation. If your company
+      allocates addresses from a range, specify the entire range, such as 203.0.113.0/24.
+      For details, see VPCs and Subnets in the AWS documentation.
+    Type: String
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: >-
+      CIDR block for the VPC. When you create a VPC, you must specify a range of IPv4
+      addresses for the VPC in the form of a Classless Inter-Domain Routing (CIDR)
+      block. You can also optionally assign an IPv6 CIDR block to your VPC, and assign
+      IPv6 CIDR blocks to your subnets.
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
+    Type: String
+Mappings:
+  Talend:
+    flags:
+      SaveCredentialsEnabled: 'true'
+Conditions:
+  CreateRdsCondition: !Equals
+    - ''
+    - !Ref 'TacDbHost'
+  CreateGitCondition: !Equals
+    - ''
+    - !Ref 'GitHost'
+  CreateRedshiftCondition: !Equals
+    - ''
+    - !Ref 'RedshiftHost'
+  CreateEmrCondition: !Equals
+    - 'true'
+    - !Ref 'CreateEmr'
+  CreateStudioCondition: !Equals
+    - !Ref 'CreateStudioStack'
+    - 'true'
+  CreateBastionCondition: !Not
+    - !Equals
+      - !Ref 'NumBastionHosts'
+      - '0'
+Resources:
+  VpcStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/bastion/submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+      Parameters:
+        AvailabilityZones: !Join
+          - ','
+          - !Ref 'AvailabilityZones'
+        KeyPairName: !Ref 'KeyPairName'
+        NumberOfAZs: '2'
+        PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
+        PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
+        PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
+        PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
+        VPCCIDR: !Ref 'VPCCIDR'
+  OodleStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/oodle.template'
+      Parameters:
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
+        KeyPairName: !Ref 'KeyPairName'
+        TalendLicenseBucket: !Ref 'TalendLicenseBucket'
+        TalendResourceBucket: !Ref 'TalendResourceBucket'
+        VpcId: !GetAtt 'VpcStack.Outputs.VPCID'
+        PublicSubnetId1: !GetAtt 'VpcStack.Outputs.PublicSubnet1ID'
+        PublicSubnetId2: !GetAtt 'VpcStack.Outputs.PublicSubnet2ID'
+        PrivateSubnetId1: !GetAtt 'VpcStack.Outputs.PrivateSubnet1AID'
+        PrivateSubnetId2: !GetAtt 'VpcStack.Outputs.PrivateSubnet2AID'
+        RemoteAccessCIDR: !Ref 'RemoteAccessCIDR'
+        TacInstanceType: !Ref 'TacInstanceType'
+        GitInstanceType: !Ref 'GitInstanceType'
+        NexusInstanceType: !Ref 'NexusInstanceType'
+        LogserverInstanceType: !Ref 'LogserverInstanceType'
+        JobserverInstanceType: !Ref 'JobserverInstanceType'
+        StudioInstanceType: !Ref 'StudioInstanceType'
+        BastionInstanceType: !Ref 'BastionInstanceType'
+        CreateEmr: !Ref 'CreateEmr'
+        CreateDistantRunStack: !Ref 'CreateDistantRunStack'
+        CreateTacDatabase: !Ref 'CreateTacDatabase'
+        CreateStudioStack: !Ref 'CreateStudioStack'
+        NexusAdminUserid: !Ref 'NexusAdminUserid'
+        NexusAdminPassword: !Ref 'NexusAdminPassword'
+        TacDbHost: !Ref 'TacDbHost'
+        TacPassword: !Ref 'TacPassword'
+        MasterDbUser: !Ref 'MasterDbUser'
+        MasterDbPassword: !Ref 'MasterDbPassword'
+        TacDbSchema: !Ref 'TacDbSchema'
+        TacDbUser: !Ref 'TacDbUser'
+        TacDbPassword: !Ref 'TacDbPassword'
+        AmcDbUser: !Ref 'AmcDbUser'
+        AmcDbPassword: !Ref 'AmcDbPassword'
+        DbClass: !Ref 'DbClass'
+        DbAllocatedStorage: !Ref 'DbAllocatedStorage'
+        RedshiftHost: !Ref 'RedshiftHost'
+        RedshiftUsername: !Ref 'RedshiftUsername'
+        RedshiftPassword: !Ref 'RedshiftPassword'
+        RedshiftDbName: !Ref 'RedshiftDbName'
+        RedshiftNodeType: !Ref 'RedshiftNodeType'
+        RedshiftNumberOfNodes: !Ref 'RedshiftNumberOfNodes'
+        EmrMasterInstanceType: !Ref 'EmrMasterInstanceType'
+        EmrCoreInstanceType: !Ref 'EmrCoreInstanceType'
+        EmrCoreNodes: !Ref 'EmrCoreNodes'
+        JobserverAutoscaleMaxSize: !Ref 'JobserverAutoscaleMaxSize'
+        JobserverAutoscaleDesiredCapacity: !Ref 'JobserverAutoscaleDesiredCapacity'
+        DistantRunAutoscaleMaxSize: !Ref 'DistantRunAutoscaleMaxSize'
+        DistantRunAutoscaleDesiredCapacity: !Ref 'DistantRunAutoscaleDesiredCapacity'
+        GitProtocol: !Ref 'GitProtocol'
+        GitHost: !Ref 'GitHost'
+        GitPort: !Ref 'GitPort'
+        GitRepo: !Ref 'GitRepo'
+        GitAdminUserid: !Ref 'GitAdminUserid'
+        GitAdminPassword: !Ref 'GitAdminPassword'
+        GitAdminEmail: !Ref 'GitAdminEmail'
+        GitTacUserid: !Ref 'GitTacUserid'
+        GitTacPassword: !Ref 'GitTacPassword'
+        GitTacEmail: !Ref 'GitTacEmail'
+        NumBastionHosts: !Ref 'NumBastionHosts'
+Outputs:
+  VpcStack:
+    Value: !Ref 'VpcStack'
+    Description: Nested VPC stack
+    Export:
+      Name: !Sub '${AWS::StackName}:VpcStack'
+  OodleStack:
+    Value: !Ref 'OodleStack'
+    Description: Nested Oodle stack
+    Export:
+      Name: !Sub '${AWS::StackName}:OodleStack'
+  GitPublicDnsName:
+    Value: !If
+      - CreateGitCondition
+      - !GetAtt 'OodleStack.Outputs.GitPublicDnsName'
+      - !Ref 'GitHost'
+    Description: Git DNS
+    Export:
+      Name: !Sub '${AWS::StackName}:GitPublicDnsName'
+  TacPublicDnsName:
+    Value: !GetAtt 'OodleStack.Outputs.TacPublicDnsName'
+    Description: TAC public DNS
+    Export:
+      Name: !Sub '${AWS::StackName}:TacPublicDnsName'
+  NexusPublicDnsName:
+    Value: !GetAtt 'OodleStack.Outputs.NexusPublicDnsName'
+    Description: Nexus public DNS
+    Export:
+      Name: !Sub '${AWS::StackName}:NexusPublicDnsName'
+  StudioPublicDnsName:
+    Condition: CreateStudioCondition
+    Value: !GetAtt 'OodleStack.Outputs.StudioPublicDnsName'
+    Description: Studio public URL
+    Export:
+      Name: !Sub '${AWS::StackName}:StudioPublicDnsName'
+  RedshiftJDBC:
+    Condition: CreateRedshiftCondition
+    Value: !GetAtt 'OodleStack.Outputs.RedshiftJDBC'
+    Description: Redshift JDBC Url
+    Export:
+      Name: !Sub '${AWS::StackName}:RedshiftJDBC'
+  RedshiftEndpoint:
+    Condition: CreateRedshiftCondition
+    Value: !GetAtt 'OodleStack.Outputs.RedshiftEndpoint'
+    Description: Redshift Endpoint
+    Export:
+      Name: !Sub '${AWS::StackName}:RedshiftEndpoint'
+  EmrMasterPublicDns:
+    Condition: CreateEmrCondition
+    Value: !GetAtt 'OodleStack.Outputs.EmrMasterPublicDns'
+    Description: EMR public DNS
+    Export:
+      Name: !Sub '${AWS::StackName}:EmrMasterPublicDns'
+  CredentialBucket:
+    Value: !GetAtt 'OodleStack.Outputs.CredentialBucket'
+    Description: Talend Credential Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:CredentialBucket'
+  TalendSourceBucket:
+    Value: !GetAtt 'OodleStack.Outputs.TalendSourceBucket'
+    Description: Talend Source Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:TalendSourceBucket'
+  TalendTargetBucket:
+    Value: !GetAtt 'OodleStack.Outputs.TalendTargetBucket'
+    Description: Talend Target Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:TalendTargetBucket'
+  EmrLogBucket:
+    Condition: CreateEmrCondition
+    Value: !GetAtt 'OodleStack.Outputs.EmrLogBucket'
+    Description: Emr Log Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:EmrLogBucket'

--- a/templates/oodle.template
+++ b/templates/oodle.template
@@ -686,7 +686,8 @@
                 "dc2.large",
                 "dc2.8xlarge",
                 "ds2.xlarge",
-                "ds2.8xlarge"
+                "ds2.8xlarge",
+                "dc1.large"
             ]
         },
 		"RedshiftNumberOfNodes": {

--- a/templates/oodle.template
+++ b/templates/oodle.template
@@ -686,8 +686,7 @@
                 "dc2.large",
                 "dc2.8xlarge",
                 "ds2.xlarge",
-                "ds2.8xlarge",
-                "dc1.large"
+                "ds2.8xlarge"
             ]
         },
 		"RedshiftNumberOfNodes": {

--- a/templates/oodle.template
+++ b/templates/oodle.template
@@ -1,1477 +1,1188 @@
-{
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This template deploys Talend Servers, Datasources (RDS, EMR, Redshift) and Bastion servers to a VPC.  The Talend servers are deployed to the public subnet with the exception of the Jobservers which are deployed to the private subnet. The RDS, EMR, and Redshift servers are all dpeloyed to the private subnet.  Private subnets must be available in at least two availability zones.  **WARNING** This template creates AWS resources. You will be billed for the AWS resources used if you create a stack from this template. (qs-1nrlpbhna)",
-    "Metadata": {
-        "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [
-                {
-                    "Label": {
-                        "default": "Network configuration"
-                    },
-                    "Parameters": [
-                        "RemoteAccessCIDR",
-						"VpcId",
-						"PublicSubnetId1",
-						"PublicSubnetId2",
-						"PrivateSubnetId1",
-						"PrivateSubnetId2"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Creation options for existing deployments"
-                    },
-                    "Parameters": [
-                        "CreateDistantRunStack",
-                        "CreateEmr",
-                        "CreateTacDatabase",
-						"CreateStudioStack"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Sizing configuration"
-                    },
-                    "Parameters": [
-                        "KeyPairName",
-                        "TacInstanceType",
-                        "LogserverInstanceType",
-                        "JobserverInstanceType",
-                        "NexusInstanceType",
-						"StudioInstanceType",
-						"GitInstanceType",
-						"BastionInstanceType",
-						"EmrCoreInstanceType",
-						"EmrMasterInstanceType",
-						"RedshiftNodeType",
-						"EmrCoreNodes",
-						"NumBastionHosts",
-						"RedshiftNumberOfNodes"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Auto Scaling configuration"
-                    },
-                    "Parameters": [
-                        "JobserverAutoscaleDesiredCapacity",
-                        "JobserverAutoscaleMaxSize",
-                        "DistantRunAutoscaleDesiredCapacity",
-                        "DistantRunAutoscaleMaxSize"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Amazon Redshift configuration"
-                    },
-                    "Parameters": [
-                        "RedshiftHost",
-                        "RedshiftUsername",
-                        "RedshiftPassword",
-                        "RedshiftDbName"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Talend Administration Center configuration"
-                    },
-                    "Parameters": [
-                        "TacDbHost",
-                        "MasterDbUser",
-                        "MasterDbPassword",
-                        "TacDbSchema",
-                        "TacUsername",
-                        "TacPassword",
-                        "TacDbUser",
-                        "TacDbPassword",
-                        "DbClass",
-                        "DbAllocatedStorage",
-						"AmcDbUser",
-						"AmcDbPassword",
-                        "TalendResourceBucket",
-                        "TalendLicenseBucket"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Talend Nexus configuration"
-                    },
-                    "Parameters": [
-                        "NexusAdminUserid",
-                        "NexusAdminPassword"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Talend Git configuration"
-                    },
-                    "Parameters": [
-                        "GitProtocol",
-                        "GitHost",
-                        "GitPort",
-                        "GitRepo",
-                        "GitAdminUserid",
-                        "GitAdminPassword",
-                        "GitAdminEmail",
-                        "GitTacUserid",
-                        "GitTacPassword",
-                        "GitTacEmail"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Quick Start Configuration"
-                    },
-                    "Parameters": [
-                        "QSS3BucketName",
-                        "QSS3KeyPrefix"
-                    ]
-                }
-            ],
-            "ParameterLabels": {
-                "QSS3BucketName": {
-                    "default": "Quick Start S3 Bucket"
-                },
-                "QSS3KeyPrefix": {
-                    "default": "Quick Start S3 Key Prefix"
-                },
-                "TalendResourceBucket": {
-                    "default": "Talend Resource Bucket"
-                },
-                "TalendLicenseBucket": {
-                    "default": "Talend License Bucket"
-                },
-                "VpcId": {
-                    "default": "VPC ID"
-                },
-                "PublicSubnetId1": {
-                    "default": "Public Subnet 1 ID"
-                },
-                "PublicSubnetId2": {
-                    "default": "Public Subnet 2 ID"
-                },
-                "PrivateSubnetId1": {
-                    "default": "Private Subnet 1 ID"
-                },
-                "PrivateSubnetId2": {
-                    "default": "Private Subnet 2 ID"
-                },
-                "CreateDistantRunStack": {
-                    "default": "Create Distant Run Stack"
-                },
-                "CreateStudioStack": {
-                    "default": "Create Studio Stack"
-                },
-                "DeleteBucket": {
-                    "default": "Delete Buckets"
-                },
-                "CreateEmr": {
-                    "default": "Create Amazon EMR"
-                },
-                "CreateTacDatabase": {
-                    "default": "Create TAC Database"
-                },
-                "RemoteAccessCIDR": {
-                    "default": "Remote Access CIDR"
-                },
-                "KeyPairName": {
-                    "default": "Key Pair Name"
-                },
-                "TacInstanceType": {
-                    "default": "TAC Instance Type"
-                },
-                "GitInstanceType": {
-                    "default": "Git Instance Type"
-                },
-                "AmcDbUser": {
-                    "default": "AMC Database Username"
-                },
-                "AmcDbPassword": {
-                    "default": "AMC Database Password"
-                },
-                "TacDbUser": {
-                    "default": "TAC Database Username"
-                },
-                "TacDbPassword": {
-                    "default": "TAC Database Password"
-                },
-                "TacDbHost": {
-                    "default": "TAC Database Host (optional)"
-                },
-                "TacDbSchema": {
-                    "default": "TAC Database Schema"
-                },
-                "TacPassword": {
-                    "default": "TAC Password"
-                },
-                "MasterDbUser": {
-                    "default": "TAC Master Database User"
-                },
-                "MasterDbPassword": {
-                    "default": "TAC Master Database Password"
-                },
-                "DbClass": {
-                    "default": "Database Instance Class"
-                },
-                "DbAllocatedStorage": {
-                    "default": "Database Allocated Storage"
-                },
-                "NexusAdminUserid": {
-                    "default": "Nexus Admin User ID"
-                },
-                "NexusAdminPassword": {
-                    "default": "Nexus Admin Password"
-                },
-                "LogserverInstanceType": {
-                    "default": "Logserver Instance Type"
-                },
-                "JobserverInstanceType": {
-                    "default": "Jobserver Instance Type"
-                },
-                "NexusInstanceType": {
-                    "default": "Nexus Instance Type"
-                },
-                "StudioInstanceType": {
-                    "default": "Studio Instance Type"
-                },
-                "BastionInstanceType": {
-                    "default": "Bastion Instance Type"
-                },
-                "JobserverAutoscaleDesiredCapacity": {
-                    "default": "Jobserver Autoscale Desired Capacity"
-                },
-                "JobserverAutoscaleMaxSize": {
-                    "default": "Jobserver Autoscale Maximum Capacity"
-                },
-                "DistantRunAutoscaleDesiredCapacity": {
-                    "default": "DistantRun Autoscale Desired Capacity"
-                },
-                "DistantRunAutoscaleMaxSize": {
-                    "default": "DistantRun Autoscale Maximum Capacity"
-                },
-                "NumBastionHosts": {
-                    "default": "Number of Bastion Hosts"
-                },
-                "RedshiftNodeType": {
-                    "default": "Amazon Redshift Node Type"
-                },
-                "RedshiftNumberOfNodes": {
-                    "default": "Number of Amazon Redshift Nodes"
-                },
-                "EmrMasterInstanceType": {
-                    "default": "Amazon EMR Master Node Instance Type"
-                },
-                "EmrCoreInstanceType": {
-                    "default": "Amazon EMR Core Node Instance Type"
-                },
-                "EmrCoreNodes": {
-                    "default": "Number of Amazon EMR Core Nodes"
-                },
-                "RedshiftHost": {
-                    "default": "Amazon Redshift Host (optional)"
-                },
-                "RedshiftDbName": {
-                    "default": "Amazon Redshift Database Name"
-                },
-                "RedshiftUsername": {
-                    "default": "Amazon Redshift Username"
-                },
-                "RedshiftPassword": {
-                    "default": "Amazon Redshift Password"
-                },
-                "GitProtocol": {
-                    "default": "Git Protocol"
-                },
-                "GitHost": {
-                    "default": "Git Host (optional)"
-                },
-                "GitPort": {
-                    "default": "Git TCP Port"
-                },
-                "GitRepo": {
-                    "default": "Git Repository"
-                },
-                "GitAdminUserid": {
-                    "default": "Git Admin User ID"
-                },
-                "GitAdminPassword": {
-                    "default": "Git Admin Password"
-                },
-                "GitAdminEmail": {
-                    "default": "Git Admin Email"
-                },
-                "GitTacUserid": {
-                    "default": "Git TAC User ID"
-                },
-                "GitTacPassword": {
-                    "default": "Git TAC Password"
-                },
-                "GitTacEmail": {
-                    "default": "Git TAC Email"
-                }
-            }
-        }
-    },
-    "Parameters": {
-        "QSS3BucketName": {
-            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$",
-            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-) or period (.).",
-            "Default": "aws-quickstart",
-            "Description": "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-) or period (.).",
-            "Type": "String"
-        },
-        "QSS3KeyPrefix": {
-            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
-            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).  Prefix cannot start with a slash but must end with a slash unless it is the empty string.",
-            "Default": "quickstart-datalake-cognizant-talend/",
-            "Description": "The S3 key name prefix used to simulate a folder for your copy of Quick Start assets, if you decide to customize or extend the Quick Start for your own use. This prefix can include numbers, lowercase letters, uppercase letters, hyphens, and forward slashes",
-            "Type": "String"
-        },
-        "KeyPairName": {
-            "Description": "Public/private key pair, which allows you to connect securely to your instance after it launches. When you created an AWS account, this is the key pair you created in your preferred region.",
-            "Type": "AWS::EC2::KeyPair::KeyName"
-        },
-        "TalendLicenseBucket": {
-            "Description": "Bucket where the Talend license is stored",
-            "Type": "String",
-            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$",
-            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-) or period (.)."
-        },
-        "TalendResourceBucket": {
-            "Description": "Bucket where the Talend binaries are stored",
-            "Type": "String",
-            "Default": "repo-quickstart-talend"
-        },
-        "VpcId": {
-            "Description": "ID of the existing VPC where the AWS resources will be deployed through the CloudFormation templates",
-            "Type": "AWS::EC2::VPC::Id"
-        },
-        "PublicSubnetId1": {
-        	"Description": "ID of Public Subnet 1 in the existing VPC",
-        	"Type": "AWS::EC2::Subnet::Id"
-        },
-        "PublicSubnetId2": {
-        	"Description": "ID of Public Subnet 2 in the existing VPC",
-        	"Type": "AWS::EC2::Subnet::Id"
-        },
-        "PrivateSubnetId1": {
-        	"Description": "ID of Private Subnet 1 in the existing VPC",
-        	"Type": "AWS::EC2::Subnet::Id"
-        },
-        "PrivateSubnetId2": {
-        	"Description": "ID of Private Subnet 2 in the existing VPC",
-        	"Type": "AWS::EC2::Subnet::Id"
-        },
-        "RemoteAccessCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
-            "Description": "The CIDR IP range that is permitted to access the VPC. We recommend that you use a constrained CIDR range to reduce the potential of inbound attacks from unknown IP addresses. For example, if your IPv4 address is 203.0.113.25, specify 203.0.113.25/32 to list this single IPv4 address in CIDR notation. If your company allocates addresses from a range, specify the entire range, such as 203.0.113.0/24. For details, see VPCs and Subnets in the AWS documentation.",
-            "Type": "String"
-        },
-        "TacInstanceType": {
-            "Description": "EC2 instance type for the Talend Administration Center",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "x1.16xlarge",
-                "x1.32xlarge",
-                "x1e.32xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "GitInstanceType": {
-            "Description": "EC2 Instance type for Git Server",
-            "Type": "String",
-            "Default": "m4.large",
-            "AllowedValues": [
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "NexusInstanceType": {
-            "Description": "EC2 Instance type for Nexus Server",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "LogserverInstanceType": {
-            "Description": "EC2 Instance type for Log Server",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "JobserverInstanceType": {
-            "Description": "EC2 Instance type for Talend Jobservers",
-            "Type": "String",
-            "Default": "t2.large",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "x1.16xlarge",
-                "x1.32xlarge",
-                "x1e.32xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "StudioInstanceType": {
-            "Description": "EC2 Instance type for Talend Studio",
-            "Type": "String",
-            "Default": "m4.xlarge",
-            "AllowedValues": [
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "t2.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
-        "BastionInstanceType": {
-            "Description": "EC2 Instance type for Bastion host",
-            "Type": "String",
-            "Default": "t2.micro",
-            "AllowedValues": [
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m3.large",
-                "m3.xlarge",
-                "m3.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge"
-            ]
-        },
-        "CreateEmr": {
-            "Description": "Set this to true to create a new EMR instance. If you do not wish to use EMR or want to use an existing EMR, set this to false.",
-            "Type": "String",
-            "Default": "true",
-            "AllowedValues": [
-                "true",
-                "false"
-            ]
-        },
-        "CreateDistantRunStack": {
-            "Description": "Set this to true to create Talend Jobserver autoscale group in public subnet for remote job submission from Talend Studio. If you do not wish to use DistantRun, set this to false.",
-            "Type": "String",
-			"Default": "true",
-            "AllowedValues": [ "true", "false" ]
-        },
-        "CreateTacDatabase": {
-            "Description": "Set this to true to create a new Talend Administration Center (TAC) database. If you do not wish to use TAC or want to use an existing database, set this to false.",
-            "Type": "String",
-            "AllowedValues": [ "true", "false" ],
-            "Default": "true"
-        },
-        "CreateStudioStack": {
-            "Description": "Set this to true to create Talend Studio EC2 instance in the public subnet. If you do not wish to use Talend Studiot, set this to false.",
-            "Type": "String",
-			"Default": "true",
-            "AllowedValues": [ "true", "false" ]
-        },
-        "NexusAdminUserid": {
-            "Description": "Administrator User Id for Nexus Server",
-            "Type": "String",
-            "Default": "admin"
-       },
-        "NexusAdminPassword": {
-            "Description": "Password for Nexus Server",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "TacDbHost": {
-            "Description": "Name or IP address of host on which an existing MySQL database runs which you intend to use as the TAC database. Leave this blank to create a new MySQL database for TAC.",
-            "Type": "String",
-            "Default": ""
-        },
-        "TacPassword": {
-            "Description": "TAC application password for tadmin account.",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "MasterDbUser": {
-            "Description": "The master or root user used to create TAC and AMC databases and the TAC user.  Only needed if creating the TAC or AMC databases",
-            "Type": "String",
-            "Default": "tadmin"
-        },
-        "MasterDbPassword": {
-            "Description": "Master user database password.  Only needed if creating the TAC or AMC databases.",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "TacDbSchema": {
-            "Description": "Existing Database schema for Talend Administration Center (TAC)",
-            "Type": "String",
-            "Default": "tac_quickstart"
-        },
-        "TacDbUser": {
-            "Description": "Existing Database Username for TAC",
-            "Type": "String",
-            "Default": "tac"
-        },
-        "TacDbPassword": {
-            "Description": "Existing Database Password for TAC",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "AmcDbUser": {
-            "Description": "Database user name for Activity Monitoring console (AMC)",
-            "Type": "String",
-            "Default": "amc"
-        },
-        "AmcDbPassword": {
-            "Description": "Databse Password for AMC",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "DbClass": {
-            "Description": "Instance class of RDS instance",
-            "Type": "String",
-            "Default": "db.t2.medium",
-            "AllowedValues": [
-                "db.t2.micro",
-                "db.t2.small",
-                "db.t2.medium",
-                "db.t2.large",
-                "db.m4.large",
-                "db.m4.xlarge",
-                "db.m4.2xlarge",
-                "db.m4.4xlarge",
-                "db.m4.10xlarge",
-                "db.r3.large",
-                "db.r3.xlarge",
-                "db.r3.2xlarge",
-                "db.r3.4xlarge",
-                "db.r3.8xlarge"
-            ]
-        },
-        "DbAllocatedStorage": {
-            "Description": "Allocated Storage (in GB) for RDS instance",
-            "Type": "Number",
-            "Default": "20"
-        },
-        "RedshiftHost": {
-            "Description": "DNS Name or IP address of the master node of an existing Redshift cluster which you intend to use for the Talend sample jobs. Leave this blank to create a new Redshift cluster.",
-            "Type": "String",
-            "Default": ""
-        },
-		"RedshiftUsername": {
-            "Description": "User name for Redshift database",
-            "Type": "String",
-            "Default": "tadmin"
-        },
-        "RedshiftPassword": {
-            "Description": "Password for Redshift. Can only contain alphanumeric characters or the following special characters!^*-_+",
-            "NoEcho": true,
-            "Type": "String",
-			"MinLength": 8,
-            "MaxLength": 28,
-            "AllowedPattern": "[a-zA-Z0-9!^*\\-_+]*"
-        },
-		"RedshiftDbName": {
-            "Description": "Database name for Redshift",
-            "Type": "String",
-            "Default": ""
-        },
-		"RedshiftNodeType": {
-            "Type": "String",
-            "Default": "dc2.large",
-            "Description": "EC2 instance type for the Redshift cluster nodes",
-            "ConstraintDescription": "must be a valid RedShift node type.",
-            "AllowedValues": [
-                "dc2.large",
-                "dc2.8xlarge",
-                "ds2.xlarge",
-                "ds2.8xlarge"
-            ]
-        },
-		"RedshiftNumberOfNodes": {
-            "Description": "The number of nodes in the redshift cluster.",
-            "Type": "Number",
-            "Default": "1"
-        },
-        "JobserverAutoscaleMaxSize": {
-            "Description": "Maximum no. of EC2 instances for Talend Jobserver autoscale group ",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "5"
-        },
-		"EmrMasterInstanceType": {
-            "AllowedValues": [
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "Default": "c4.xlarge",
-            "Description": "Instance type for the EMR master node. Default is m4.large",
-            "Type": "String"
-        },
-		"EmrCoreInstanceType": {
-            "AllowedValues": [
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "m4.16xlarge",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "r4.large",
-                "r4.xlarge",
-                "r4.2xlarge",
-                "r4.4xlarge",
-                "r4.8xlarge",
-                "r4.16xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "i3.large",
-                "i3.xlarge",
-                "i3.2xlarge",
-                "i3.4xlarge",
-                "i3.8xlarge",
-                "i3.16xlarge"
-            ],
-            "Default": "c4.xlarge",
-            "Description": "Instance type for the EMR core nodes",
-            "Type": "String"
-        },
-		"EmrCoreNodes": {
-            "Description": "Number of EMR Core Nodes. Minimum 1",
-            "MaxValue": "500",
-            "MinValue": "1",
-            "Type": "Number",
-			"Default": "2"
-        },
-        "JobserverAutoscaleDesiredCapacity": {
-            "Description": "Desired no. of EC2 instances for Talend Jobserver autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "1"
-        },
-        "DistantRunAutoscaleMaxSize": {
-            "Description": "Maximum no. of EC2 instances for Talend DistantRun Autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "5"
-        },
-        "DistantRunAutoscaleDesiredCapacity": {
-            "Description": "Desired number of EC2 instances for Talend DistantRun Autoscale group",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "10",
-            "Default": "1"
-        },
-        "GitProtocol": {
-            "Description": "Git protocol",
-            "Type": "String",
-            "Default": "http"
-        },
-        "GitHost": {
-            "Description": "Host name of Git",
-            "Type": "String",
-            "Default": ""
-        },
-        "GitPort": {
-            "Description": "Port number of GIT",
-            "Type": "Number",
-            "MinValue": "1",
-            "MaxValue": "65535",
-            "Default": "443"
-        },
-        "GitRepo": {
-            "Description": "Name of Git repository.",
-            "Type": "String",
-            "Default": "oodlejobs"
-        },
-        "GitAdminUserid": {
-            "Description": "Unique user id of Git administrator, must be different than GitTacUserid",
-            "Type": "String",
-            "Default": "tadmin"
-        },
-        "GitAdminPassword": {
-            "Description": "Password for GIT administrator",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "GitAdminEmail": {
-            "Description": "Unique email address of Git administrator, must be different than GitTacEmail",
-            "Type": "String",
-            "Default": ""
-        },
-        "GitTacUserid": {
-            "Description": "Unique user id for GIT TAC, must be different than GitAdminUserid",
-            "Type": "String",
-            "Default": "tac"
-        },
-        "GitTacPassword": {
-            "Description": "Password for GIT TAC",
-            "Type": "String",
-            "NoEcho": "true"
-        },
-        "GitTacEmail": {
-            "Description": "Unique contact email address for TAC, must be different than GitAdminEmail",
-            "Type": "String",
-            "Default": ""
-        },
-        "NumBastionHosts": {
-            "AllowedValues": [ "0", "1", "2", "3", "4" ],
-            "Default": "1",
-            "Description": "The number of Linux bastion hosts to run. Auto Scaling will ensure that you always have this number of bastion hosts running. The maximum is 4 bastion hosts.",
-            "Type": "String"
-        }
-    },
-    "Rules": {
-        "SubnetsInVPC": {
-            "Assertions": [
-                {
-                    "Assert": {
-                        "Fn::EachMemberIn": [
-                            {
-                                "Fn::ValueOfAll": [
-                                    "AWS::EC2::Subnet::Id",
-                                    "VpcId"
-                                ]
-                            },
-                            {
-                                "Fn::RefAll": "AWS::EC2::VPC::Id"
-                            }
-                        ]
-                    },
-                    "AssertDescription": "All subnets must exist in the VPC"
-                }
-            ]
-        }
-    },
-    "Mappings": {
-        "Datasource": {
-            "Redshift": {
-                "port": "5439"
-            }
-        }
-    },
-    "Conditions": {
-        "CreateRdsCondition": { 
-            "Fn::Equals": [ "", { "Ref": "TacDbHost" } ]
-        },
-        "CreateRedshiftCondition": {
-            "Fn::Equals": [ "", { "Ref": "RedshiftHost" } ]
-        },
-        "CreateEmrCondition": {
-            "Fn::Equals": [ "true", { "Ref": "CreateEmr" } ]
-        },
-        "CreateGitCondition": {
-            "Fn::Equals": [ "", { "Ref": "GitHost" } ]
-        },
-        "CreateStudioCondition": {
-            "Fn::Equals": [
-                { "Ref": "CreateStudioStack" },
-                "true"
-            ]
-        },
-        "CreateBastionCondition": {
-            "Fn::Not": [
-                { "Fn::Equals": [ { "Ref": "NumBastionHosts" }, "0" ] }
-            ]
-        },
-        "enableDeleteBuckets": {
-            "Fn::Equals": [
-                "true",
-                "true"
-            ]
-        }
-    },
-    "Resources": {
-
-        "BucketsStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-buckets.template" },
-                "Parameters": {
-                    "CreateEmr": { "Ref": "CreateEmr" }
-                }
-            }
-        },
-
-        "IamStack": {
-			"Type" : "AWS::CloudFormation::Stack",
-			"Properties" : {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-iam.template" },
-				"Parameters" : {
-                    "QSS3BucketName": { "Ref": "QSS3BucketName" },
-                    "QSS3KeyPrefix": { "Fn::Sub": "${QSS3KeyPrefix}modules/talend/" },
-					"TalendLicenseBucket":  { "Ref": "TalendLicenseBucket" },
-                    "TalendResourceBucket": { "Ref": "TalendResourceBucket" },
-                    "TalendSourceBucket": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendSourceBucket" ] },
-                    "TalendTargetBucket": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendTargetBucket" ] },
-                    "StackRoot": { "Fn::Sub": "${AWS::StackName}" }
-                }
-            }
-        },
-    
-        "BastionSecurityGroupsStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": {
-                    "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/bastion/templates/linux-bastion-securitygroups.template"
-                },
-                "Parameters": {
-                    "VPCID": { "Ref": "VpcId" },
-                    "RemoteAccessCIDR": { "Ref": "RemoteAccessCIDR" }
-                }
-            }
-        },
-
-        "TalendSecurityGroupsStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-securitygroups.template" },
-                "Parameters": {
-                    "VpcId": { "Ref": "VpcId" },
-                    "RemoteAccessCIDR": { "Ref": "RemoteAccessCIDR" }
-                }
-            }
-        },
-
-        "DataSourceSecurityGroupsStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-securitygroups.template" },
-                "Parameters": {
-                    "VpcId": { "Ref": "VpcId" },
-                    "RedshiftPort": { "Fn::FindInMap": [ "Datasource", "Redshift", "port" ] },
-                    "RemoteAccessCIDR": { "Ref": "RemoteAccessCIDR" },
-                    "CreateRedshift": { "Fn::If": [ "CreateRedshiftCondition", "true", "false" ] },
-                    "CreateEmr": { "Ref": "CreateEmr" }
-                }
-            }
-        },
-
-        "EmrSecurityGroupsStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-emr-securitygroups.template" },
-                "Parameters": {
-                    "VpcId": { "Ref": "VpcId" }
-                }
-            }
-        },
-
-        "OodleSecurityGroupsStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/oodle-securitygroups.template" },
-                "Parameters": {
-                    "BastionSecurityGroupID": { 
-                        "Fn::If": [ 
-                            "CreateBastionCondition", 
-                            { "Fn::GetAtt": [ "BastionSecurityGroupsStack", "Outputs.BastionSecurityGroupID"] },
-                            "" 
-                        ]
-                    },
-                    "RedshiftSecurityGroupID": { 
-                        "Fn::If": [ 
-                            "CreateRedshiftCondition", 
-                            { "Fn::GetAtt": [ "DataSourceSecurityGroupsStack", "Outputs.RedshiftSecurityGroupID"] },
-                            "" 
-                        ]
-                    },
-                    "RedshiftPort": { 
-                        "Fn::If": [ 
-                            "CreateRedshiftCondition", 
-                            { "Fn::FindInMap": [ "Datasource", "Redshift", "port"] },
-                            "" 
-                        ]
-                    },
-                    "EmrSecurityGroupID": { 
-                        "Fn::If": [ 
-                            "CreateEmrCondition", 
-                            { "Fn::GetAtt": [ "DataSourceSecurityGroupsStack", "Outputs.EmrSecurityGroupID"] },
-                            "" 
-                        ]
-                    },
-                    "DatabaseSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.DatabaseSecurityGroupID"] },
-                    "StudioSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.StudioSecurityGroupID" ] },
-                    "DistantRunSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.DistantRunSecurityGroupID" ] },
-                    "TacSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.TacSecurityGroupID" ] },
-                    "JobserverSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.JobserverSecurityGroupID" ] },
-                    "NexusSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.NexusSecurityGroupID" ] },
-                    "LogserverSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.LogserverSecurityGroupID" ] },
-                    "CommandlineSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.CommandlineSecurityGroupID" ] },
-                    "GitSecurityGroupID": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.GitSecurityGroupID" ] }
-                }
-            }
-        },
-
-        "BastionStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Condition": "CreateBastionCondition",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/bastion/templates/linux-bastion.template" },
-                "Parameters": {
-                    "QSS3BucketName": { "Ref": "QSS3BucketName" },
-                    "QSS3KeyPrefix": { "Fn::Sub": "${QSS3KeyPrefix}modules/bastion/" },
-                    "VPCID": { "Ref": "VpcId" },
-                    "PublicSubnet1ID": { "Ref": "PublicSubnetId1" },
-                    "PublicSubnet2ID": { "Ref": "PublicSubnetId2" },
-                    "RemoteAccessCIDR": { "Ref": "RemoteAccessCIDR" },
-                    "KeyPairName": { "Ref": "KeyPairName" },
-                    "BastionSecurityGroup": { "Fn::GetAtt": [ "BastionSecurityGroupsStack", "Outputs.BastionSecurityGroupID"] },
-                    "NumBastionHosts": { "Ref": "NumBastionHosts" },
-                    "BastionAMIOS": "Amazon-Linux-HVM",
-                    "BastionInstanceType": { "Ref": "BastionInstanceType" },
-                    "BastionBanner": "https://aws-quickstart.s3.amazonaws.com/quickstart-linux-bastion/scripts/banner_message.txt",
-                    "EnableBanner": "false",
-                    "EnableTCPForwarding": "true",
-                    "EnableX11Forwarding": "true"
-                }
-            }
-        },
-
-        "TalendDbStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Condition": "CreateRdsCondition",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-rds.template" },
-                "Parameters": {
-                    "Subnets": { "Fn::Join": [ ",",
-                        [ { "Ref": "PrivateSubnetId1" },
-                        { "Ref": "PrivateSubnetId2" } ]
-                    ] },
-                    "SecurityGroups": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.DatabaseSecurityGroupID" ] },
-                    "Engine": "mysql",
-                    "DbClass": { "Ref": "DbClass" },
-                    "Port": "3306",
-                    "DbAllocatedStorage": { "Ref": "DbAllocatedStorage" },
-                    "MasterDbUser": { "Ref": "MasterDbUser" },
-                    "MasterDbPassword": { "Ref": "MasterDbPassword" }
-                }
-            }
-        },
-
-		"StudioStack": {
-			"Type" : "AWS::CloudFormation::Stack",
-            "Condition" : "CreateStudioCondition",
-			"Properties" : {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-studio-ubuntu.template" },
-				"Parameters" : {
-                    "QSS3BucketName": { "Ref": "QSS3BucketName" },
-                    "QSS3KeyPrefix": { "Fn::Sub": "${QSS3KeyPrefix}modules/talend/" },
-					"TalendLicenseBucket":  { "Ref": "TalendLicenseBucket" },
-                    "InstanceRole": { "Fn::GetAtt": [ "IamStack", "Outputs.InstanceRole" ] },
-                    "InstanceProfile": { "Fn::GetAtt": [ "IamStack", "Outputs.InstanceProfile" ] },
-					"InstanceType": { "Ref": "StudioInstanceType" },
-					"KeyName": { "Ref": "KeyPairName" },
-                    "SubnetId": { "Ref": "PublicSubnetId1" },
-                    "PrivateSubnet": "public",
-                    "TacIp": { "Fn::GetAtt": [ "TalendServersStack", "Outputs.TacIp" ] },
-                    "SecurityGroupIds": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.StudioSecurityGroupID" ] },
-                    "TalendResourceBucket": { "Ref": "TalendResourceBucket" },
-                    "TacStack": { "Fn::GetAtt": [ "TalendServersStack", "Outputs.TacStack" ] }
-				},
-				"TimeoutInMinutes" : "10"
-			}
-        },
-
-        "RedshiftStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Condition": "CreateRedshiftCondition",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-redshift.template" },
-                "TimeoutInMinutes": 30,
-                "Parameters": {
-                    "RedshiftSubnetA": { "Ref": "PrivateSubnetId1" },
-                    "RedshiftSubnetB": { "Ref": "PrivateSubnetId2" },
-                    "RedshiftSecurityGroup": { "Fn::GetAtt": [ "DataSourceSecurityGroupsStack", "Outputs.RedshiftSecurityGroupID"] },
-                    "RedshiftUsername": { "Ref": "RedshiftUsername" },
-                    "RedshiftPassword": { "Ref": "RedshiftPassword" },
-                    "RedshiftDbName": { "Ref": "RedshiftDbName" },
-                    "RedshiftPort": "5439",
-                    "RedshiftNodeType": { "Ref": "RedshiftNodeType" },
-                    "RedshiftNumberOfNodes": { "Ref": "RedshiftNumberOfNodes" }
-                }
-            }
-        },
-
-        "EmrStack": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Condition": "CreateEmrCondition",
-            "Properties": {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-emr.template" },
-                "TimeoutInMinutes": 30,
-                "Parameters": {
-                    "KeyPair": { "Ref": "KeyPairName" },
-                    "EmrSubnetA": { "Ref": "PrivateSubnetId1" },
-                    "EmrLogBucketDnsName": { "Fn::GetAtt": [ "BucketsStack", "Outputs.EmrLogBucketDnsName" ] },
-                    "EmrMasterInstanceType": { "Ref": "EmrMasterInstanceType" },
-                    "EmrCoreInstanceType": { "Ref": "EmrCoreInstanceType" },
-                    "EmrCoreNodes": { "Ref": "EmrCoreNodes" },
-                    "EmrSecurityGroup": { "Fn::GetAtt": [ "DataSourceSecurityGroupsStack", "Outputs.EmrSecurityGroupID" ] },
-                    "RemoteAccessEmrSecurityGroup": { "Fn::GetAtt": [ "DataSourceSecurityGroupsStack", "Outputs.RemoteAccessEmrSecurityGroupID" ] },
-                    "EmrMasterSecurityGroup": { "Fn::GetAtt": [ "EmrSecurityGroupsStack", "Outputs.EmrMasterSecurityGroupId" ] },
-					"EmrSlaveSecurityGroup": { "Fn::GetAtt": [ "EmrSecurityGroupsStack", "Outputs.EmrSlaveSecurityGroupId" ] },
-					"EmrServiceAccessSecurityGroup": { "Fn::GetAtt": [ "EmrSecurityGroupsStack", "Outputs.EmrServiceAccessSecurityGroupId" ] }
-                }
-            }
-        },
-
-        "TalendServersStack": {
-			"Type" : "AWS::CloudFormation::Stack",
-			"Properties" : {
-                "TemplateURL": { "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-servers.template" },
-				"TimeoutInMinutes" : "10",
-				"Parameters" : {
-                    "QSS3BucketName": { "Ref": "QSS3BucketName" },
-                    "QSS3KeyPrefix": { "Fn::Sub": "${QSS3KeyPrefix}modules/talend/" },
-                    "KeyName": { "Ref": "KeyPairName" },
-
-					"TalendLicenseBucket":  { "Ref": "TalendLicenseBucket" },
-                    "TalendResourceBucket": { "Ref": "TalendResourceBucket" },
-                    "TalendSourceBucket": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendSourceBucket" ] },
-
-                    "InstanceRole": { "Fn::GetAtt": [ "IamStack", "Outputs.InstanceRole" ] },
-                    "InstanceProfile": { "Fn::GetAtt": [ "IamStack", "Outputs.InstanceProfile" ] },
-
-                    "PublicSubnetId1": { "Ref": "PublicSubnetId1" },
-                    "PublicSubnetId2": { "Ref": "PublicSubnetId2" },
-                    "PrivateSubnetId1": { "Ref": "PrivateSubnetId1" },
-                    "PrivateSubnetId2": { "Ref": "PrivateSubnetId2" },
-
-                    "CreateDistantRunStack": { "Ref": "CreateDistantRunStack" },
-
-                    "JobserverAutoscaleMinSize": "1",
-                    "JobserverAutoscaleMaxSize": { "Ref": "JobserverAutoscaleMaxSize" },
-                    "JobserverAutoscaleDesiredCapacity": {  "Ref": "JobserverAutoscaleDesiredCapacity" },
-                    "DistantRunAutoscaleMinSize": "1",
-                    "DistantRunAutoscaleMaxSize": { "Ref": "DistantRunAutoscaleMaxSize" },
-                    "DistantRunAutoscaleDesiredCapacity": {  "Ref": "DistantRunAutoscaleDesiredCapacity" },
-
-                    "TacInstanceType": { "Ref": "TacInstanceType" },
-                    "GitInstanceType": { "Ref": "GitInstanceType" },
-                    "NexusInstanceType": { "Ref": "NexusInstanceType" },
-                    "LogserverInstanceType": { "Ref": "LogserverInstanceType" },
-                    "JobserverInstanceType": { "Ref": "JobserverInstanceType" },
-
-                    "TacSecurityGroup": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.TacSecurityGroupID" ] },
-					"NexusSecurityGroup": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.NexusSecurityGroupID" ] },
-					"LogserverSecurityGroup": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.LogserverSecurityGroupID" ] },
-                    "JobserverSecurityGroup": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.JobserverSecurityGroupID" ] },
-                    "DistantRunSecurityGroup": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.DistantRunSecurityGroupID" ] },
-                    "GitSecurityGroup": { "Fn::GetAtt": [ "TalendSecurityGroupsStack", "Outputs.GitSecurityGroupID" ] },
-
-                    "NexusPort": "8081",
-                    "NexusAdminUserid": { "Ref": "NexusAdminUserid" },
-                    "NexusAdminPassword": { "Ref": "NexusAdminPassword" },
-                    
-                    "TacDbHost": {
-                        "Fn::If": [
-                            "CreateRdsCondition",
-                            { "Fn::GetAtt": [ "TalendDbStack", "Outputs.EndpointAddress" ] },
-                            { "Ref": "TacDbHost" } 
-                        ]
-                    },
-                    "TacPassword": { "Ref": "TacPassword" },
-                    "MasterDbUser": { "Ref": "MasterDbUser" },
-                    "MasterDbPassword": { "Ref": "MasterDbPassword" },
-                    "TacDbSchema": { "Ref": "TacDbSchema" },
-                    "TacDbUser": { "Ref": "TacDbUser" },
-                    "TacDbPassword": { "Ref": "TacDbPassword" },
-                    "AmcDbUser": { "Ref": "AmcDbUser" },
-                    "AmcDbPassword": { "Ref": "AmcDbPassword" },
-                    "CreateTacDatabase": { "Ref": "CreateTacDatabase" },
-                    "CreateAmcDatabase": { "Ref": "CreateTacDatabase" },
-
-                    "GitHost": { "Ref": "GitHost" },
-                    "GitProtocol": { "Ref": "GitProtocol" },
-                    "GitPort": { "Ref": "GitPort" },
-                    "GitRepo": { "Ref": "GitRepo" },
-                    "GitAdminUserid": { "Ref": "GitAdminUserid" },
-                    "GitAdminPassword": { "Ref": "GitAdminPassword" },
-                    "GitAdminEmail": { "Ref": "GitAdminEmail" },
-                    "GitTacUserid": { "Ref": "GitTacUserid" },
-                    "GitTacPassword": { "Ref": "GitTacPassword" },
-                    "GitTacEmail": { "Ref": "GitTacEmail" }
-                }
-            }
-        },
-
-        "CredentialBucket": {
-            "Type": "AWS::S3::Bucket",
-            "Properties": {
-                "AccessControl": "Private"
-            }
-        },
-
-		"CredentialStore": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Properties": {
-                "TemplateURL": {
-                        "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/credential-store.template"
-                },
-                "TimeoutInMinutes": "10",
-                "Parameters": {
-
-                    "CredentialBucket": { "Ref": "CredentialBucket" },
-                    "CredentialBucketDnsName": { "Fn::GetAtt": [ "CredentialBucket", "DomainName" ] },
-                    "CredentialBucketArn": { "Fn::GetAtt": [ "CredentialBucket", "Arn" ] },
-                    "TalendSourceBucket": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendSourceBucket" ] },
-                    "TalendTargetBucket": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendTargetBucket" ] },
-
-                    "EmrMaster": {
-                        "Fn::If": [
-                            "CreateEmrCondition",
-                            { "Fn::GetAtt": [ "EmrStack", "Outputs.EmrMasterPublicDns" ] },
-                            {"Ref" : "AWS::NoValue"} 
-                        ]
-                    },
-
-                    "RedshiftHost": {
-                        "Fn::If": [
-                            "CreateRedshiftCondition",
-                            { "Fn::GetAtt": [ "RedshiftStack", "Outputs.RedshiftEndpoint" ] },
-                            { "Ref": "RedshiftHost" } 
-                        ]
-                    },
-                    "RedshiftPort": { "Fn::FindInMap": [ "Datasource", "Redshift", "port" ] },
-                    "RedshiftUsername": { "Ref": "RedshiftUsername" },
-                    "RedshiftPassword": { "Ref": "RedshiftPassword"},
-                    "RedshiftDbName": { "Ref": "RedshiftDbName" },
-
-                    "TacDbHost": {
-                        "Fn::If": [
-                            "CreateRdsCondition",
-                            { "Fn::GetAtt": [ "TalendDbStack", "Outputs.EndpointAddress" ] },
-                            { "Ref": "TacDbHost" } 
-                        ]
-                    },
-                    "TacDbPort": "3306",
-                    "MasterDbUser": { "Ref": "MasterDbUser" },
-                    "MasterDbPassword": { "Ref": "MasterDbPassword" },
-                    "TacDbSchema": { "Ref": "TacDbSchema" },
-                    "TacUsername": { "Ref": "TacDbUser" },
-                    "TacPassword": { "Ref": "TacDbPassword" },
-
-                    "GitProtocol": { "Ref": "GitProtocol" },
-                    "GitHost": {
-                        "Fn::If": [
-                            "CreateGitCondition",
-                            { "Fn::GetAtt": [ "TalendServersStack", "Outputs.GitDnsName" ] },
-                            { "Ref": "GitHost" } 
-                        ]
-                    },
-                    "GitPort": { "Ref": "GitPort" },
-                    "GitRepo": { "Ref": "GitRepo" },
-                    "GitAdminEmail": { "Ref": "GitAdminEmail" },
-                    "GitAdminUserid": { "Ref": "GitAdminUserid" },
-                    "GitAdminPassword": { "Ref": "GitAdminPassword" },
-                    "GitTacEmail": { "Ref": "GitTacEmail" },
-                    "GitTacUserid": { "Ref": "GitTacUserid" },
-                    "GitTacPassword": { "Ref": "GitTacPassword" },
-
-                    "NexusPort": "8081",
-                    "NexusAdminUserid": { "Ref": "NexusAdminUserid" },
-                    "NexusAdminPassword": { "Ref": "NexusAdminPassword" }
-                }
-			}
-        },
-
-		"DeleteBuckets": {
-            "Type": "AWS::CloudFormation::Stack",
-            "Condition": "enableDeleteBuckets",
-            "DependsOn": [ "BucketsStack", "OodleSecurityGroupsStack" ],
-            "Properties": {
-                "TemplateURL": {
-                        "Fn::Sub": "http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/delete-buckets.template"
-                },
-                "Parameters": {
-                    "DelBucket1": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendSourceBucket" ] },
-                    "DelBucket2": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendTargetBucket" ] },
-                    "DelBucket3": { "Ref": "CredentialBucket" },
-                    "DelBucket4": {
-                        "Fn::If" : [
-							"CreateEmrCondition",						
-							{ "Fn::GetAtt": [ "BucketsStack", "Outputs.EmrLogBucket" ] },
-							""
-						]
-                    }
-                }
-            }
-        }
-
-    },
-    "Outputs": {
-        "IamStack": {
-            "Value": { "Ref": "IamStack" },
-            "Description": "Nested IAM stack",
-			"Export": {
-				"Name": {
-					"Fn::Sub": "${AWS::StackName}:IamStack"
-				} 
-			}
-        },
-        "TalendSecurityGroupsStack": {
-            "Value": { "Ref": "TalendSecurityGroupsStack" },
-            "Description": "Nested Talend Security Group stack",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:SecurityGroupsStack" } 
-				} 
-        },
-        "TalendDbStack": {
-            "Condition": "CreateRdsCondition",
-            "Value": { "Ref": "TalendDbStack" },
-            "Description": "Nested Talend DB stack",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TalendDbStack" } 
-				} 
-        },
-        "StudioStack": {
-            "Condition": "CreateStudioCondition",
-            "Value": { "Ref": "StudioStack" },
-            "Description": "Nested Studio stack",
-			"Export": {
-				"Name": {
-					"Fn::Sub": "${AWS::StackName}:StudioStack"
-				} 
-			}
-        },
-        "BastionStack": {
-            "Condition": "CreateBastionCondition",
-            "Value": { "Ref": "BastionStack" },
-            "Description": "Nested Bastion stack",
-			"Export": {
-				"Name": {
-					"Fn::Sub": "${AWS::StackName}:BastionStack"
-				} 
-			}
-        },
-        "TalendServersStack": {
-            "Value": { "Ref": "TalendServersStack" },
-            "Description": "Nested Talend Servers stack",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TalendServersStack" } 
-				} 
-        },
-        "TacPublicDnsName": {
-            "Value": { "Fn::GetAtt": [ "TalendServersStack", "Outputs.TacDnsName"] },
-            "Description": "TAC public DNS",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TacPublicDnsName" } 
-			}
-        },
-        "NexusPublicDnsName": {
-            "Value": { "Fn::GetAtt": [ "TalendServersStack", "Outputs.NexusDnsName"] },
-            "Description": "Nexus public DNS address",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:NexusPublicDnsName" } 
-			}
-        },
-        "GitPublicDnsName": {
-            "Value": { 
-                "Fn::If": [
-                    "CreateGitCondition",
-                    { "Fn::GetAtt": [ "TalendServersStack", "Outputs.GitDnsName" ] },
-                    { "Ref": "GitHost" } 
-                ]
-            },
-            "Description": "Git public DNS address",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:GitPublicDnsName" } 
-			}
-        },
-        "StudioPublicDnsName": {
-            "Condition": "CreateStudioCondition",			
-            "Value": { "Fn::GetAtt": [ "StudioStack", "Outputs.publicDnsName"] },
-            "Description": "Studio public DNS address",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:StudioPublicDnsName" } 
-			}
-        },		
-        "RedshiftJDBC": {
-            "Condition": "CreateRedshiftCondition",		
-            "Value": { "Fn::GetAtt": [ "RedshiftStack", "Outputs.RedshiftJdbcUrl"] },
-            "Description": "Redshift JDBC Url",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:RedshiftJDBC" } 
-			}
-        },
-		"RedshiftEndpoint": {
-            "Condition": "CreateRedshiftCondition",		
-            "Value": { "Fn::GetAtt": [ "RedshiftStack", "Outputs.RedshiftEndpoint"] },
-            "Description": "Redshift Endpoint",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:RedshiftEndpoint" } 
-			}
-        },
-		"EmrMasterPublicDns": {
-            "Condition": "CreateEmrCondition",		
-            "Value": { "Fn::GetAtt": [ "EmrStack", "Outputs.EmrMasterPublicDns"] },
-            "Description": "EMR public DNS",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:EmrMasterPublicDns" } 
-			}
-        },
-		"CredentialBucket": {	
-            "Value": { "Ref": "CredentialBucket" },
-            "Description": "Credential Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:CredentialBucket" } 
-			}
-        },		
-		"TalendSourceBucket": {	
-            "Value": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendSourceBucket"] },
-            "Description": "Talend Source Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TalendSourceBucket" } 
-			}
-        },	
-		"TalendTargetBucket": {	
-            "Value": { "Fn::GetAtt": [ "BucketsStack", "Outputs.TalendTargetBucket"] },
-            "Description": "Talend Target Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:TalendTargetBucket" } 
-			}
-        },
-		"EmrLogBucket": {
-            "Condition": "CreateEmrCondition",		
-            "Value": { "Fn::GetAtt": [ "BucketsStack", "Outputs.EmrLogBucket"] },
-            "Description": "Emr Log Bucket",
-			"Export": {
-				"Name": { "Fn::Sub": "${AWS::StackName}:EmrLogBucket" } 
-			}
-        }
-		
-    }
-}
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  This template deploys Talend Servers, Datasources (RDS, EMR, Redshift) and Bastion
+  servers to a VPC.  The Talend servers are deployed to the public subnet with the
+  exception of the Jobservers which are deployed to the private subnet. The RDS, EMR,
+  and Redshift servers are all dpeloyed to the private subnet.  Private subnets must
+  be available in at least two availability zones.  **WARNING** This template creates
+  AWS resources. You will be billed for the AWS resources used if you create a stack
+  from this template. (qs-1nrlpbhna)
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network configuration
+        Parameters:
+          - RemoteAccessCIDR
+          - VpcId
+          - PublicSubnetId1
+          - PublicSubnetId2
+          - PrivateSubnetId1
+          - PrivateSubnetId2
+      - Label:
+          default: Creation options for existing deployments
+        Parameters:
+          - CreateDistantRunStack
+          - CreateEmr
+          - CreateTacDatabase
+          - CreateStudioStack
+      - Label:
+          default: Sizing configuration
+        Parameters:
+          - KeyPairName
+          - TacInstanceType
+          - LogserverInstanceType
+          - JobserverInstanceType
+          - NexusInstanceType
+          - StudioInstanceType
+          - GitInstanceType
+          - BastionInstanceType
+          - EmrCoreInstanceType
+          - EmrMasterInstanceType
+          - RedshiftNodeType
+          - EmrCoreNodes
+          - NumBastionHosts
+          - RedshiftNumberOfNodes
+      - Label:
+          default: Auto Scaling configuration
+        Parameters:
+          - JobserverAutoscaleDesiredCapacity
+          - JobserverAutoscaleMaxSize
+          - DistantRunAutoscaleDesiredCapacity
+          - DistantRunAutoscaleMaxSize
+      - Label:
+          default: Amazon Redshift configuration
+        Parameters:
+          - RedshiftHost
+          - RedshiftUsername
+          - RedshiftPassword
+          - RedshiftDbName
+      - Label:
+          default: Talend Administration Center configuration
+        Parameters:
+          - TacDbHost
+          - MasterDbUser
+          - MasterDbPassword
+          - TacDbSchema
+          - TacUsername
+          - TacPassword
+          - TacDbUser
+          - TacDbPassword
+          - DbClass
+          - DbAllocatedStorage
+          - AmcDbUser
+          - AmcDbPassword
+          - TalendResourceBucket
+          - TalendLicenseBucket
+      - Label:
+          default: Talend Nexus configuration
+        Parameters:
+          - NexusAdminUserid
+          - NexusAdminPassword
+      - Label:
+          default: Talend Git configuration
+        Parameters:
+          - GitProtocol
+          - GitHost
+          - GitPort
+          - GitRepo
+          - GitAdminUserid
+          - GitAdminPassword
+          - GitAdminEmail
+          - GitTacUserid
+          - GitTacPassword
+          - GitTacEmail
+      - Label:
+          default: Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+    ParameterLabels:
+      QSS3BucketName:
+        default: Quick Start S3 Bucket
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix
+      TalendResourceBucket:
+        default: Talend Resource Bucket
+      TalendLicenseBucket:
+        default: Talend License Bucket
+      VpcId:
+        default: VPC ID
+      PublicSubnetId1:
+        default: Public Subnet 1 ID
+      PublicSubnetId2:
+        default: Public Subnet 2 ID
+      PrivateSubnetId1:
+        default: Private Subnet 1 ID
+      PrivateSubnetId2:
+        default: Private Subnet 2 ID
+      CreateDistantRunStack:
+        default: Create Distant Run Stack
+      CreateStudioStack:
+        default: Create Studio Stack
+      DeleteBucket:
+        default: Delete Buckets
+      CreateEmr:
+        default: Create Amazon EMR
+      CreateTacDatabase:
+        default: Create TAC Database
+      RemoteAccessCIDR:
+        default: Remote Access CIDR
+      KeyPairName:
+        default: Key Pair Name
+      TacInstanceType:
+        default: TAC Instance Type
+      GitInstanceType:
+        default: Git Instance Type
+      AmcDbUser:
+        default: AMC Database Username
+      AmcDbPassword:
+        default: AMC Database Password
+      TacDbUser:
+        default: TAC Database Username
+      TacDbPassword:
+        default: TAC Database Password
+      TacDbHost:
+        default: TAC Database Host (optional)
+      TacDbSchema:
+        default: TAC Database Schema
+      TacPassword:
+        default: TAC Password
+      MasterDbUser:
+        default: TAC Master Database User
+      MasterDbPassword:
+        default: TAC Master Database Password
+      DbClass:
+        default: Database Instance Class
+      DbAllocatedStorage:
+        default: Database Allocated Storage
+      NexusAdminUserid:
+        default: Nexus Admin User ID
+      NexusAdminPassword:
+        default: Nexus Admin Password
+      LogserverInstanceType:
+        default: Logserver Instance Type
+      JobserverInstanceType:
+        default: Jobserver Instance Type
+      NexusInstanceType:
+        default: Nexus Instance Type
+      StudioInstanceType:
+        default: Studio Instance Type
+      BastionInstanceType:
+        default: Bastion Instance Type
+      JobserverAutoscaleDesiredCapacity:
+        default: Jobserver Autoscale Desired Capacity
+      JobserverAutoscaleMaxSize:
+        default: Jobserver Autoscale Maximum Capacity
+      DistantRunAutoscaleDesiredCapacity:
+        default: DistantRun Autoscale Desired Capacity
+      DistantRunAutoscaleMaxSize:
+        default: DistantRun Autoscale Maximum Capacity
+      NumBastionHosts:
+        default: Number of Bastion Hosts
+      RedshiftNodeType:
+        default: Amazon Redshift Node Type
+      RedshiftNumberOfNodes:
+        default: Number of Amazon Redshift Nodes
+      EmrMasterInstanceType:
+        default: Amazon EMR Master Node Instance Type
+      EmrCoreInstanceType:
+        default: Amazon EMR Core Node Instance Type
+      EmrCoreNodes:
+        default: Number of Amazon EMR Core Nodes
+      RedshiftHost:
+        default: Amazon Redshift Host (optional)
+      RedshiftDbName:
+        default: Amazon Redshift Database Name
+      RedshiftUsername:
+        default: Amazon Redshift Username
+      RedshiftPassword:
+        default: Amazon Redshift Password
+      GitProtocol:
+        default: Git Protocol
+      GitHost:
+        default: Git Host (optional)
+      GitPort:
+        default: Git TCP Port
+      GitRepo:
+        default: Git Repository
+      GitAdminUserid:
+        default: Git Admin User ID
+      GitAdminPassword:
+        default: Git Admin Password
+      GitAdminEmail:
+        default: Git Admin Email
+      GitTacUserid:
+        default: Git TAC User ID
+      GitTacPassword:
+        default: Git TAC Password
+      GitTacEmail:
+        default: Git TAC Email
+Parameters:
+  QSS3BucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, periods (.), and hyphens (-). It cannot start or
+      end with a hyphen (-) or period (.).
+    Default: aws-quickstart
+    Description: >-
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include
+      numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-).
+      It cannot start or end with a hyphen (-) or period (.).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: >-
+      Quick Start key prefix can include numbers, lowercase letters, uppercase letters,
+      hyphens (-), and forward slash (/).  Prefix cannot start with a slash but must
+      end with a slash unless it is the empty string.
+    Default: quickstart-datalake-cognizant-talend/
+    Description: >-
+      The S3 key name prefix used to simulate a folder for your copy of Quick Start
+      assets, if you decide to customize or extend the Quick Start for your own use.
+      This prefix can include numbers, lowercase letters, uppercase letters, hyphens,
+      and forward slashes
+    Type: String
+  KeyPairName:
+    Description: Public/private key pair, which allows you to connect securely to
+      your instance after it launches. When you created an AWS account, this is the
+      key pair you created in your preferred region.
+    Type: AWS::EC2::KeyPair::KeyName
+  TalendLicenseBucket:
+    Description: Bucket where the Talend license is stored
+    Type: String
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, periods (.), and hyphens (-). It cannot start or
+      end with a hyphen (-) or period (.).
+  TalendResourceBucket:
+    Description: Bucket where the Talend binaries are stored
+    Type: String
+    Default: repo-quickstart-talend
+  VpcId:
+    Description: ID of the existing VPC where the AWS resources will be deployed through
+      the CloudFormation templates
+    Type: AWS::EC2::VPC::Id
+  PublicSubnetId1:
+    Description: ID of Public Subnet 1 in the existing VPC
+    Type: AWS::EC2::Subnet::Id
+  PublicSubnetId2:
+    Description: ID of Public Subnet 2 in the existing VPC
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnetId1:
+    Description: ID of Private Subnet 1 in the existing VPC
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnetId2:
+    Description: ID of Private Subnet 2 in the existing VPC
+    Type: AWS::EC2::Subnet::Id
+  RemoteAccessCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: >-
+      The CIDR IP range that is permitted to access the VPC. We recommend that you
+      use a constrained CIDR range to reduce the potential of inbound attacks from
+      unknown IP addresses. For example, if your IPv4 address is 203.0.113.25, specify
+      203.0.113.25/32 to list this single IPv4 address in CIDR notation. If your company
+      allocates addresses from a range, specify the entire range, such as 203.0.113.0/24.
+      For details, see VPCs and Subnets in the AWS documentation.
+    Type: String
+  TacInstanceType:
+    Description: EC2 instance type for the Talend Administration Center
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.32xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  GitInstanceType:
+    Description: EC2 Instance type for Git Server
+    Type: String
+    Default: m4.large
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  NexusInstanceType:
+    Description: EC2 Instance type for Nexus Server
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  LogserverInstanceType:
+    Description: EC2 Instance type for Log Server
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  JobserverInstanceType:
+    Description: EC2 Instance type for Talend Jobservers
+    Type: String
+    Default: t2.large
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.32xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  StudioInstanceType:
+    Description: EC2 Instance type for Talend Studio
+    Type: String
+    Default: m4.xlarge
+    AllowedValues:
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  BastionInstanceType:
+    Description: EC2 Instance type for Bastion host
+    Type: String
+    Default: t2.micro
+    AllowedValues:
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+  CreateEmr:
+    Description: Set this to true to create a new EMR instance. If you do not wish
+      to use EMR or want to use an existing EMR, set this to false.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  CreateDistantRunStack:
+    Description: Set this to true to create Talend Jobserver autoscale group in public
+      subnet for remote job submission from Talend Studio. If you do not wish to use
+      DistantRun, set this to false.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  CreateTacDatabase:
+    Description: Set this to true to create a new Talend Administration Center (TAC)
+      database. If you do not wish to use TAC or want to use an existing database,
+      set this to false.
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+  CreateStudioStack:
+    Description: Set this to true to create Talend Studio EC2 instance in the public
+      subnet. If you do not wish to use Talend Studiot, set this to false.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  NexusAdminUserid:
+    Description: Administrator User Id for Nexus Server
+    Type: String
+    Default: admin
+  NexusAdminPassword:
+    Description: Password for Nexus Server
+    Type: String
+    NoEcho: 'true'
+  TacDbHost:
+    Description: Name or IP address of host on which an existing MySQL database runs
+      which you intend to use as the TAC database. Leave this blank to create a new
+      MySQL database for TAC.
+    Type: String
+    Default: ''
+  TacPassword:
+    Description: TAC application password for tadmin account.
+    Type: String
+    NoEcho: 'true'
+  MasterDbUser:
+    Description: The master or root user used to create TAC and AMC databases and
+      the TAC user.  Only needed if creating the TAC or AMC databases
+    Type: String
+    Default: tadmin
+  MasterDbPassword:
+    Description: Master user database password.  Only needed if creating the TAC or
+      AMC databases.
+    Type: String
+    NoEcho: 'true'
+  TacDbSchema:
+    Description: Existing Database schema for Talend Administration Center (TAC)
+    Type: String
+    Default: tac_quickstart
+  TacDbUser:
+    Description: Existing Database Username for TAC
+    Type: String
+    Default: tac
+  TacDbPassword:
+    Description: Existing Database Password for TAC
+    Type: String
+    NoEcho: 'true'
+  AmcDbUser:
+    Description: Database user name for Activity Monitoring console (AMC)
+    Type: String
+    Default: amc
+  AmcDbPassword:
+    Description: Databse Password for AMC
+    Type: String
+    NoEcho: 'true'
+  DbClass:
+    Description: Instance class of RDS instance
+    Type: String
+    Default: db.t2.medium
+    AllowedValues:
+      - db.t2.micro
+      - db.t2.small
+      - db.t2.medium
+      - db.t2.large
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.r3.large
+      - db.r3.xlarge
+      - db.r3.2xlarge
+      - db.r3.4xlarge
+      - db.r3.8xlarge
+  DbAllocatedStorage:
+    Description: Allocated Storage (in GB) for RDS instance
+    Type: Number
+    Default: '20'
+  RedshiftHost:
+    Description: DNS Name or IP address of the master node of an existing Redshift
+      cluster which you intend to use for the Talend sample jobs. Leave this blank
+      to create a new Redshift cluster.
+    Type: String
+    Default: ''
+  RedshiftUsername:
+    Description: User name for Redshift database
+    Type: String
+    Default: tadmin
+  RedshiftPassword:
+    Description: Password for Redshift. Can only contain alphanumeric characters or
+      the following special characters!^*-_+
+    NoEcho: true
+    Type: String
+    MinLength: 8
+    MaxLength: 28
+    AllowedPattern: '[a-zA-Z0-9!^*\-_+]*'
+  RedshiftDbName:
+    Description: Database name for Redshift
+    Type: String
+    Default: ''
+  RedshiftNodeType:
+    Type: String
+    Default: dc2.large
+    Description: EC2 instance type for the Redshift cluster nodes
+    ConstraintDescription: must be a valid RedShift node type.
+    AllowedValues:
+      - dc2.large
+      - dc2.8xlarge
+      - ds2.xlarge
+      - ds2.8xlarge
+  RedshiftNumberOfNodes:
+    Description: The number of nodes in the redshift cluster.
+    Type: Number
+    Default: '1'
+  JobserverAutoscaleMaxSize:
+    Description: 'Maximum no. of EC2 instances for Talend Jobserver autoscale group '
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '5'
+  EmrMasterInstanceType:
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    Default: c4.xlarge
+    Description: Instance type for the EMR master node. Default is m4.large
+    Type: String
+  EmrCoreInstanceType:
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+    Default: c4.xlarge
+    Description: Instance type for the EMR core nodes
+    Type: String
+  EmrCoreNodes:
+    Description: Number of EMR Core Nodes. Minimum 1
+    MaxValue: '500'
+    MinValue: '1'
+    Type: Number
+    Default: '2'
+  JobserverAutoscaleDesiredCapacity:
+    Description: Desired no. of EC2 instances for Talend Jobserver autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '1'
+  DistantRunAutoscaleMaxSize:
+    Description: Maximum no. of EC2 instances for Talend DistantRun Autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '5'
+  DistantRunAutoscaleDesiredCapacity:
+    Description: Desired number of EC2 instances for Talend DistantRun Autoscale group
+    Type: Number
+    MinValue: '1'
+    MaxValue: '10'
+    Default: '1'
+  GitProtocol:
+    Description: Git protocol
+    Type: String
+    Default: http
+  GitHost:
+    Description: Host name of Git
+    Type: String
+    Default: ''
+  GitPort:
+    Description: Port number of GIT
+    Type: Number
+    MinValue: '1'
+    MaxValue: '65535'
+    Default: '443'
+  GitRepo:
+    Description: Name of Git repository.
+    Type: String
+    Default: oodlejobs
+  GitAdminUserid:
+    Description: Unique user id of Git administrator, must be different than GitTacUserid
+    Type: String
+    Default: tadmin
+  GitAdminPassword:
+    Description: Password for GIT administrator
+    Type: String
+    NoEcho: 'true'
+  GitAdminEmail:
+    Description: Unique email address of Git administrator, must be different than
+      GitTacEmail
+    Type: String
+    Default: ''
+  GitTacUserid:
+    Description: Unique user id for GIT TAC, must be different than GitAdminUserid
+    Type: String
+    Default: tac
+  GitTacPassword:
+    Description: Password for GIT TAC
+    Type: String
+    NoEcho: 'true'
+  GitTacEmail:
+    Description: Unique contact email address for TAC, must be different than GitAdminEmail
+    Type: String
+    Default: ''
+  NumBastionHosts:
+    AllowedValues:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+    Default: '1'
+    Description: The number of Linux bastion hosts to run. Auto Scaling will ensure
+      that you always have this number of bastion hosts running. The maximum is 4
+      bastion hosts.
+    Type: String
+Rules:
+  SubnetsInVPC:
+    Assertions:
+      - Assert: !EachMemberIn
+          - !ValueOfAll
+            - AWS::EC2::Subnet::Id
+            - VpcId
+          - !RefAll 'AWS::EC2::VPC::Id'
+        AssertDescription: All subnets must exist in the VPC
+Mappings:
+  Datasource:
+    Redshift:
+      port: '5439'
+Conditions:
+  CreateRdsCondition: !Equals
+    - ''
+    - !Ref 'TacDbHost'
+  CreateRedshiftCondition: !Equals
+    - ''
+    - !Ref 'RedshiftHost'
+  CreateEmrCondition: !Equals
+    - 'true'
+    - !Ref 'CreateEmr'
+  CreateGitCondition: !Equals
+    - ''
+    - !Ref 'GitHost'
+  CreateStudioCondition: !Equals
+    - !Ref 'CreateStudioStack'
+    - 'true'
+  CreateBastionCondition: !Not
+    - !Equals
+      - !Ref 'NumBastionHosts'
+      - '0'
+  enableDeleteBuckets: !Equals
+    - 'true'
+    - 'true'
+Resources:
+  BucketsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-buckets.template'
+      Parameters:
+        CreateEmr: !Ref 'CreateEmr'
+  IamStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-iam.template'
+      Parameters:
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}modules/talend/'
+        TalendLicenseBucket: !Ref 'TalendLicenseBucket'
+        TalendResourceBucket: !Ref 'TalendResourceBucket'
+        TalendSourceBucket: !GetAtt 'BucketsStack.Outputs.TalendSourceBucket'
+        TalendTargetBucket: !GetAtt 'BucketsStack.Outputs.TalendTargetBucket'
+        StackRoot: !Sub '${AWS::StackName}'
+  BastionSecurityGroupsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/bastion/templates/linux-bastion-securitygroups.template'
+      Parameters:
+        VPCID: !Ref 'VpcId'
+        RemoteAccessCIDR: !Ref 'RemoteAccessCIDR'
+  TalendSecurityGroupsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-securitygroups.template'
+      Parameters:
+        VpcId: !Ref 'VpcId'
+        RemoteAccessCIDR: !Ref 'RemoteAccessCIDR'
+  DataSourceSecurityGroupsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-securitygroups.template'
+      Parameters:
+        VpcId: !Ref 'VpcId'
+        RedshiftPort: !FindInMap
+          - Datasource
+          - Redshift
+          - port
+        RemoteAccessCIDR: !Ref 'RemoteAccessCIDR'
+        CreateRedshift: !If
+          - CreateRedshiftCondition
+          - 'true'
+          - 'false'
+        CreateEmr: !Ref 'CreateEmr'
+  EmrSecurityGroupsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-emr-securitygroups.template'
+      Parameters:
+        VpcId: !Ref 'VpcId'
+  OodleSecurityGroupsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/oodle-securitygroups.template'
+      Parameters:
+        BastionSecurityGroupID: !If
+          - CreateBastionCondition
+          - !GetAtt 'BastionSecurityGroupsStack.Outputs.BastionSecurityGroupID'
+          - ''
+        RedshiftSecurityGroupID: !If
+          - CreateRedshiftCondition
+          - !GetAtt 'DataSourceSecurityGroupsStack.Outputs.RedshiftSecurityGroupID'
+          - ''
+        RedshiftPort: !If
+          - CreateRedshiftCondition
+          - !FindInMap
+            - Datasource
+            - Redshift
+            - port
+          - ''
+        EmrSecurityGroupID: !If
+          - CreateEmrCondition
+          - !GetAtt 'DataSourceSecurityGroupsStack.Outputs.EmrSecurityGroupID'
+          - ''
+        DatabaseSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.DatabaseSecurityGroupID'
+        StudioSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.StudioSecurityGroupID'
+        DistantRunSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.DistantRunSecurityGroupID'
+        TacSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.TacSecurityGroupID'
+        JobserverSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.JobserverSecurityGroupID'
+        NexusSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.NexusSecurityGroupID'
+        LogserverSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.LogserverSecurityGroupID'
+        CommandlineSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.CommandlineSecurityGroupID'
+        GitSecurityGroupID: !GetAtt 'TalendSecurityGroupsStack.Outputs.GitSecurityGroupID'
+  BastionStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: CreateBastionCondition
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/bastion/templates/linux-bastion.template'
+      Parameters:
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}modules/bastion/'
+        VPCID: !Ref 'VpcId'
+        PublicSubnet1ID: !Ref 'PublicSubnetId1'
+        PublicSubnet2ID: !Ref 'PublicSubnetId2'
+        RemoteAccessCIDR: !Ref 'RemoteAccessCIDR'
+        KeyPairName: !Ref 'KeyPairName'
+        BastionSecurityGroup: !GetAtt 'BastionSecurityGroupsStack.Outputs.BastionSecurityGroupID'
+        NumBastionHosts: !Ref 'NumBastionHosts'
+        BastionAMIOS: Amazon-Linux-HVM
+        BastionInstanceType: !Ref 'BastionInstanceType'
+        BastionBanner: https://aws-quickstart.s3.amazonaws.com/quickstart-linux-bastion/scripts/banner_message.txt
+        EnableBanner: 'false'
+        EnableTCPForwarding: 'true'
+        EnableX11Forwarding: 'true'
+  TalendDbStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: CreateRdsCondition
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-rds.template'
+      Parameters:
+        Subnets: !Join
+          - ','
+          - - !Ref 'PrivateSubnetId1'
+            - !Ref 'PrivateSubnetId2'
+        SecurityGroups: !GetAtt 'TalendSecurityGroupsStack.Outputs.DatabaseSecurityGroupID'
+        Engine: mysql
+        DbClass: !Ref 'DbClass'
+        Port: '3306'
+        DbAllocatedStorage: !Ref 'DbAllocatedStorage'
+        MasterDbUser: !Ref 'MasterDbUser'
+        MasterDbPassword: !Ref 'MasterDbPassword'
+  StudioStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: CreateStudioCondition
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-studio-ubuntu.template'
+      Parameters:
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}modules/talend/'
+        TalendLicenseBucket: !Ref 'TalendLicenseBucket'
+        InstanceRole: !GetAtt 'IamStack.Outputs.InstanceRole'
+        InstanceProfile: !GetAtt 'IamStack.Outputs.InstanceProfile'
+        InstanceType: !Ref 'StudioInstanceType'
+        KeyName: !Ref 'KeyPairName'
+        SubnetId: !Ref 'PublicSubnetId1'
+        PrivateSubnet: public
+        TacIp: !GetAtt 'TalendServersStack.Outputs.TacIp'
+        SecurityGroupIds: !GetAtt 'TalendSecurityGroupsStack.Outputs.StudioSecurityGroupID'
+        TalendResourceBucket: !Ref 'TalendResourceBucket'
+        TacStack: !GetAtt 'TalendServersStack.Outputs.TacStack'
+      TimeoutInMinutes: '10'
+  RedshiftStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: CreateRedshiftCondition
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-redshift.template'
+      TimeoutInMinutes: 30
+      Parameters:
+        RedshiftSubnetA: !Ref 'PrivateSubnetId1'
+        RedshiftSubnetB: !Ref 'PrivateSubnetId2'
+        RedshiftSecurityGroup: !GetAtt 'DataSourceSecurityGroupsStack.Outputs.RedshiftSecurityGroupID'
+        RedshiftUsername: !Ref 'RedshiftUsername'
+        RedshiftPassword: !Ref 'RedshiftPassword'
+        RedshiftDbName: !Ref 'RedshiftDbName'
+        RedshiftPort: '5439'
+        RedshiftNodeType: !Ref 'RedshiftNodeType'
+        RedshiftNumberOfNodes: !Ref 'RedshiftNumberOfNodes'
+  EmrStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: CreateEmrCondition
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/datasource/templates/datasource-emr.template'
+      TimeoutInMinutes: 30
+      Parameters:
+        KeyPair: !Ref 'KeyPairName'
+        EmrSubnetA: !Ref 'PrivateSubnetId1'
+        EmrLogBucketDnsName: !GetAtt 'BucketsStack.Outputs.EmrLogBucketDnsName'
+        EmrMasterInstanceType: !Ref 'EmrMasterInstanceType'
+        EmrCoreInstanceType: !Ref 'EmrCoreInstanceType'
+        EmrCoreNodes: !Ref 'EmrCoreNodes'
+        EmrSecurityGroup: !GetAtt 'DataSourceSecurityGroupsStack.Outputs.EmrSecurityGroupID'
+        RemoteAccessEmrSecurityGroup: !GetAtt 'DataSourceSecurityGroupsStack.Outputs.RemoteAccessEmrSecurityGroupID'
+        EmrMasterSecurityGroup: !GetAtt 'EmrSecurityGroupsStack.Outputs.EmrMasterSecurityGroupId'
+        EmrSlaveSecurityGroup: !GetAtt 'EmrSecurityGroupsStack.Outputs.EmrSlaveSecurityGroupId'
+        EmrServiceAccessSecurityGroup: !GetAtt 'EmrSecurityGroupsStack.Outputs.EmrServiceAccessSecurityGroupId'
+  TalendServersStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}modules/talend/templates/talend-servers.template'
+      TimeoutInMinutes: '30'
+      Parameters:
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}modules/talend/'
+        KeyName: !Ref 'KeyPairName'
+        TalendLicenseBucket: !Ref 'TalendLicenseBucket'
+        TalendResourceBucket: !Ref 'TalendResourceBucket'
+        TalendSourceBucket: !GetAtt 'BucketsStack.Outputs.TalendSourceBucket'
+        InstanceRole: !GetAtt 'IamStack.Outputs.InstanceRole'
+        InstanceProfile: !GetAtt 'IamStack.Outputs.InstanceProfile'
+        PublicSubnetId1: !Ref 'PublicSubnetId1'
+        PublicSubnetId2: !Ref 'PublicSubnetId2'
+        PrivateSubnetId1: !Ref 'PrivateSubnetId1'
+        PrivateSubnetId2: !Ref 'PrivateSubnetId2'
+        CreateDistantRunStack: !Ref 'CreateDistantRunStack'
+        JobserverAutoscaleMinSize: '1'
+        JobserverAutoscaleMaxSize: !Ref 'JobserverAutoscaleMaxSize'
+        JobserverAutoscaleDesiredCapacity: !Ref 'JobserverAutoscaleDesiredCapacity'
+        DistantRunAutoscaleMinSize: '1'
+        DistantRunAutoscaleMaxSize: !Ref 'DistantRunAutoscaleMaxSize'
+        DistantRunAutoscaleDesiredCapacity: !Ref 'DistantRunAutoscaleDesiredCapacity'
+        TacInstanceType: !Ref 'TacInstanceType'
+        GitInstanceType: !Ref 'GitInstanceType'
+        NexusInstanceType: !Ref 'NexusInstanceType'
+        LogserverInstanceType: !Ref 'LogserverInstanceType'
+        JobserverInstanceType: !Ref 'JobserverInstanceType'
+        TacSecurityGroup: !GetAtt 'TalendSecurityGroupsStack.Outputs.TacSecurityGroupID'
+        NexusSecurityGroup: !GetAtt 'TalendSecurityGroupsStack.Outputs.NexusSecurityGroupID'
+        LogserverSecurityGroup: !GetAtt 'TalendSecurityGroupsStack.Outputs.LogserverSecurityGroupID'
+        JobserverSecurityGroup: !GetAtt 'TalendSecurityGroupsStack.Outputs.JobserverSecurityGroupID'
+        DistantRunSecurityGroup: !GetAtt 'TalendSecurityGroupsStack.Outputs.DistantRunSecurityGroupID'
+        GitSecurityGroup: !GetAtt 'TalendSecurityGroupsStack.Outputs.GitSecurityGroupID'
+        NexusPort: '8081'
+        NexusAdminUserid: !Ref 'NexusAdminUserid'
+        NexusAdminPassword: !Ref 'NexusAdminPassword'
+        TacDbHost: !If
+          - CreateRdsCondition
+          - !GetAtt 'TalendDbStack.Outputs.EndpointAddress'
+          - !Ref 'TacDbHost'
+        TacPassword: !Ref 'TacPassword'
+        MasterDbUser: !Ref 'MasterDbUser'
+        MasterDbPassword: !Ref 'MasterDbPassword'
+        TacDbSchema: !Ref 'TacDbSchema'
+        TacDbUser: !Ref 'TacDbUser'
+        TacDbPassword: !Ref 'TacDbPassword'
+        AmcDbUser: !Ref 'AmcDbUser'
+        AmcDbPassword: !Ref 'AmcDbPassword'
+        CreateTacDatabase: !Ref 'CreateTacDatabase'
+        CreateAmcDatabase: !Ref 'CreateTacDatabase'
+        GitHost: !Ref 'GitHost'
+        GitProtocol: !Ref 'GitProtocol'
+        GitPort: !Ref 'GitPort'
+        GitRepo: !Ref 'GitRepo'
+        GitAdminUserid: !Ref 'GitAdminUserid'
+        GitAdminPassword: !Ref 'GitAdminPassword'
+        GitAdminEmail: !Ref 'GitAdminEmail'
+        GitTacUserid: !Ref 'GitTacUserid'
+        GitTacPassword: !Ref 'GitTacPassword'
+        GitTacEmail: !Ref 'GitTacEmail'
+  CredentialBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+  CredentialStore:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/credential-store.template'
+      TimeoutInMinutes: '10'
+      Parameters:
+        CredentialBucket: !Ref 'CredentialBucket'
+        CredentialBucketDnsName: !GetAtt 'CredentialBucket.DomainName'
+        CredentialBucketArn: !GetAtt 'CredentialBucket.Arn'
+        TalendSourceBucket: !GetAtt 'BucketsStack.Outputs.TalendSourceBucket'
+        TalendTargetBucket: !GetAtt 'BucketsStack.Outputs.TalendTargetBucket'
+        EmrMaster: !If
+          - CreateEmrCondition
+          - !GetAtt 'EmrStack.Outputs.EmrMasterPublicDns'
+          - !Ref 'AWS::NoValue'
+        RedshiftHost: !If
+          - CreateRedshiftCondition
+          - !GetAtt 'RedshiftStack.Outputs.RedshiftEndpoint'
+          - !Ref 'RedshiftHost'
+        RedshiftPort: !FindInMap
+          - Datasource
+          - Redshift
+          - port
+        RedshiftUsername: !Ref 'RedshiftUsername'
+        RedshiftPassword: !Ref 'RedshiftPassword'
+        RedshiftDbName: !Ref 'RedshiftDbName'
+        TacDbHost: !If
+          - CreateRdsCondition
+          - !GetAtt 'TalendDbStack.Outputs.EndpointAddress'
+          - !Ref 'TacDbHost'
+        TacDbPort: '3306'
+        MasterDbUser: !Ref 'MasterDbUser'
+        MasterDbPassword: !Ref 'MasterDbPassword'
+        TacDbSchema: !Ref 'TacDbSchema'
+        TacUsername: !Ref 'TacDbUser'
+        TacPassword: !Ref 'TacDbPassword'
+        GitProtocol: !Ref 'GitProtocol'
+        GitHost: !If
+          - CreateGitCondition
+          - !GetAtt 'TalendServersStack.Outputs.GitDnsName'
+          - !Ref 'GitHost'
+        GitPort: !Ref 'GitPort'
+        GitRepo: !Ref 'GitRepo'
+        GitAdminEmail: !Ref 'GitAdminEmail'
+        GitAdminUserid: !Ref 'GitAdminUserid'
+        GitAdminPassword: !Ref 'GitAdminPassword'
+        GitTacEmail: !Ref 'GitTacEmail'
+        GitTacUserid: !Ref 'GitTacUserid'
+        GitTacPassword: !Ref 'GitTacPassword'
+        NexusPort: '8081'
+        NexusAdminUserid: !Ref 'NexusAdminUserid'
+        NexusAdminPassword: !Ref 'NexusAdminPassword'
+  DeleteBuckets:
+    Type: AWS::CloudFormation::Stack
+    Condition: enableDeleteBuckets
+    DependsOn:
+      - BucketsStack
+      - OodleSecurityGroupsStack
+    Properties:
+      TemplateURL: !Sub 'http://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/delete-buckets.template'
+      Parameters:
+        DelBucket1: !GetAtt 'BucketsStack.Outputs.TalendSourceBucket'
+        DelBucket2: !GetAtt 'BucketsStack.Outputs.TalendTargetBucket'
+        DelBucket3: !Ref 'CredentialBucket'
+        DelBucket4: !If
+          - CreateEmrCondition
+          - !GetAtt 'BucketsStack.Outputs.EmrLogBucket'
+          - ''
+Outputs:
+  IamStack:
+    Value: !Ref 'IamStack'
+    Description: Nested IAM stack
+    Export:
+      Name: !Sub '${AWS::StackName}:IamStack'
+  TalendSecurityGroupsStack:
+    Value: !Ref 'TalendSecurityGroupsStack'
+    Description: Nested Talend Security Group stack
+    Export:
+      Name: !Sub '${AWS::StackName}:SecurityGroupsStack'
+  TalendDbStack:
+    Condition: CreateRdsCondition
+    Value: !Ref 'TalendDbStack'
+    Description: Nested Talend DB stack
+    Export:
+      Name: !Sub '${AWS::StackName}:TalendDbStack'
+  StudioStack:
+    Condition: CreateStudioCondition
+    Value: !Ref 'StudioStack'
+    Description: Nested Studio stack
+    Export:
+      Name: !Sub '${AWS::StackName}:StudioStack'
+  BastionStack:
+    Condition: CreateBastionCondition
+    Value: !Ref 'BastionStack'
+    Description: Nested Bastion stack
+    Export:
+      Name: !Sub '${AWS::StackName}:BastionStack'
+  TalendServersStack:
+    Value: !Ref 'TalendServersStack'
+    Description: Nested Talend Servers stack
+    Export:
+      Name: !Sub '${AWS::StackName}:TalendServersStack'
+  TacPublicDnsName:
+    Value: !GetAtt 'TalendServersStack.Outputs.TacDnsName'
+    Description: TAC public DNS
+    Export:
+      Name: !Sub '${AWS::StackName}:TacPublicDnsName'
+  NexusPublicDnsName:
+    Value: !GetAtt 'TalendServersStack.Outputs.NexusDnsName'
+    Description: Nexus public DNS address
+    Export:
+      Name: !Sub '${AWS::StackName}:NexusPublicDnsName'
+  GitPublicDnsName:
+    Value: !If
+      - CreateGitCondition
+      - !GetAtt 'TalendServersStack.Outputs.GitDnsName'
+      - !Ref 'GitHost'
+    Description: Git public DNS address
+    Export:
+      Name: !Sub '${AWS::StackName}:GitPublicDnsName'
+  StudioPublicDnsName:
+    Condition: CreateStudioCondition
+    Value: !GetAtt 'StudioStack.Outputs.publicDnsName'
+    Description: Studio public DNS address
+    Export:
+      Name: !Sub '${AWS::StackName}:StudioPublicDnsName'
+  RedshiftJDBC:
+    Condition: CreateRedshiftCondition
+    Value: !GetAtt 'RedshiftStack.Outputs.RedshiftJdbcUrl'
+    Description: Redshift JDBC Url
+    Export:
+      Name: !Sub '${AWS::StackName}:RedshiftJDBC'
+  RedshiftEndpoint:
+    Condition: CreateRedshiftCondition
+    Value: !GetAtt 'RedshiftStack.Outputs.RedshiftEndpoint'
+    Description: Redshift Endpoint
+    Export:
+      Name: !Sub '${AWS::StackName}:RedshiftEndpoint'
+  EmrMasterPublicDns:
+    Condition: CreateEmrCondition
+    Value: !GetAtt 'EmrStack.Outputs.EmrMasterPublicDns'
+    Description: EMR public DNS
+    Export:
+      Name: !Sub '${AWS::StackName}:EmrMasterPublicDns'
+  CredentialBucket:
+    Value: !Ref 'CredentialBucket'
+    Description: Credential Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:CredentialBucket'
+  TalendSourceBucket:
+    Value: !GetAtt 'BucketsStack.Outputs.TalendSourceBucket'
+    Description: Talend Source Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:TalendSourceBucket'
+  TalendTargetBucket:
+    Value: !GetAtt 'BucketsStack.Outputs.TalendTargetBucket'
+    Description: Talend Target Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:TalendTargetBucket'
+  EmrLogBucket:
+    Condition: CreateEmrCondition
+    Value: !GetAtt 'BucketsStack.Outputs.EmrLogBucket'
+    Description: Emr Log Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}:EmrLogBucket'


### PR DESCRIPTION
CloudFormation templates in quickstart-datalake-cognizant-talend have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.